### PR TITLE
Add AppVeyor CI test/build process - Fixes #16

### DIFF
--- a/Tests/Unit/psgithub.tests.ps1
+++ b/Tests/Unit/psgithub.tests.ps1
@@ -1,0 +1,61 @@
+#
+# This is a PowerShell Unit Test file.
+# You need a unit test framework such as Pester to run PowerShell Unit tests. 
+# You can download Pester from http://go.microsoft.com/fwlink/?LinkID=534084
+#
+
+$Global:ModuleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
+
+$OldLocation = Get-Location
+Set-Location -Path $ModuleRoot
+if (Get-Module PSGitHub -All)
+{
+    Get-Module PSGitHub -All | Remove-Module
+}
+
+Import-Module "$Global:ModuleRoot\PSGitHub.psd1" -Force -DisableNameChecking
+$Global:ArtifactPath = "$Global:PSGitHub\Artifacts"
+$null = New-Item -Path "$Global:ArtifactPath" -ItemType Directory -Force -ErrorAction SilentlyContinue
+
+# Perform PS Script Analyzer tests on module code only
+$null = Set-PackageSource -Name PSGallery -Trusted -Force
+$null = Install-Module -Name 'PSScriptAnalyzer' -Confirm:$False
+Import-Module -Name 'PSScriptAnalyzer'
+
+Describe 'PSScriptAnalyzer' {
+    Context 'PSGitHub Module code and Lib Functions' {
+        It 'Passes Invoke-ScriptAnalyzer' {
+            # Perform PSScriptAnalyzer scan.
+            $PSScriptAnalyzerResult = Invoke-ScriptAnalyzer `
+                -path "$ModuleRoot\PSGitHub.psm1" `
+                -Severity Warning `
+                -ErrorAction SilentlyContinue
+            $PSScriptAnalyzerResult += Invoke-ScriptAnalyzer `
+                -path "$ModuleRoot\Functions\*.ps1" `
+                -Severity Warning `
+                -ErrorAction SilentlyContinue
+            $PSScriptAnalyzerErrors = $PSScriptAnalyzerResult | Where-Object { $_.Severity -eq 'Error' }
+            $PSScriptAnalyzerWarnings = $PSScriptAnalyzerResult | Where-Object { $_.Severity -eq 'Warning' }
+            if ($PSScriptAnalyzerErrors -ne $null)
+            {
+                Write-Warning -Message 'There are PSScriptAnalyzer errors that need to be fixed:'
+                @($PSScriptAnalyzerErrors).Foreach( { Write-Warning -Message "$($_.Scriptname) (Line $($_.Line)): $($_.Message)" } )
+                Write-Warning -Message  'For instructions on how to run PSScriptAnalyzer on your own machine, please go to https://github.com/powershell/psscriptAnalyzer/'
+                $PSScriptAnalyzerErrors.Count | Should Be $null
+            }
+            if ($PSScriptAnalyzerWarnings -ne $null)
+            {
+                Write-Warning -Message 'There are PSScriptAnalyzer warnings that should be fixed:'
+                @($PSScriptAnalyzerWarnings).Foreach( { Write-Warning -Message "$($_.Scriptname) (Line $($_.Line)): $($_.Message)" } )
+            }
+        }
+    }
+}
+
+InModuleScope PSGitHub {
+
+#region Functions
+#endregion
+}
+
+Set-Location -Path $OldLocation

--- a/Tests/Unit/psgithub.tests.ps1
+++ b/Tests/Unit/psgithub.tests.ps1
@@ -4,66 +4,86 @@
 # You can download Pester from http://go.microsoft.com/fwlink/?LinkID=534084
 #
 
-$Global:ModuleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
+$ModuleRoot = "..\..\$($Script:MyInvocation.MyCommand.Path)"
 
-$OldLocation = Get-Location
-Set-Location -Path $ModuleRoot
-if (Get-Module PSGitHub -All)
-{
-    Get-Module PSGitHub -All | Remove-Module
-}
+Push-Location `
+    -Path $ModuleRoot
+Get-Module `
+    -Name PSGitHub `
+    -All | Remove-Module
 
-Import-Module "$Global:ModuleRoot\PSGitHub.psd1" -Force -DisableNameChecking
-$Global:ArtifactPath = "$Global:ModuleRoot\Artifacts"
-$null = New-Item -Path "$Global:ArtifactPath" -ItemType Directory -Force -ErrorAction SilentlyContinue
+Import-Module `
+    -Name "$ModuleRoot\PSGitHub.psd1" `
+    -Force `
+    -DisableNameChecking
+$Global:ArtifactPath = "$ModuleRoot\Artifacts"
+$null = New-Item `
+    -Path $ArtifactPath `
+    -ItemType Directory `
+    -Force `
+    -ErrorAction SilentlyContinue
 
 # Perform PS Script Analyzer tests on module code only
-$null = Set-PackageSource -Name PSGallery -Trusted -Force
-$null = Install-Module -Name 'PSScriptAnalyzer' -Confirm:$False
-Import-Module -Name 'PSScriptAnalyzer'
+$null = Set-PackageSource `
+    -Name PSGallery `
+    -Trusted `
+    -Force
+$null = Install-Module `
+    -Name PSScriptAnalyzer `
+    -Confirm:$False
+Import-Module `
+    -Name PSScriptAnalyzer
 
 Describe 'PSScriptAnalyzer' {
     Context 'PSGitHub Module, Functions and TabCompleters' {
         It 'Passes Invoke-ScriptAnalyzer' {
             # Perform PSScriptAnalyzer scan.
             $PSScriptAnalyzerResult = Invoke-ScriptAnalyzer `
-                -path "$ModuleRoot\PSGitHub.psm1" `
+                -Path "$ModuleRoot\PSGitHub.psm1" `
                 -Severity Warning `
                 -ErrorAction SilentlyContinue
             $PSScriptAnalyzerResult += Invoke-ScriptAnalyzer `
-                -path "$ModuleRoot\Functions\Public\*.ps1" `
+                -Path "$ModuleRoot\Functions\Public\*.ps1" `
                 -Severity Warning `
                 -ErrorAction SilentlyContinue
             $PSScriptAnalyzerResult += Invoke-ScriptAnalyzer `
                 -path "$ModuleRoot\Functions\Private\*.ps1" `
-                -Severity Warning `
+                -Peverity Warning `
                 -ErrorAction SilentlyContinue
             $PSScriptAnalyzerResult += Invoke-ScriptAnalyzer `
-                -path "$ModuleRoot\TabCompleters\*.ps1" `
+                -Path "$ModuleRoot\TabCompleters\*.ps1" `
                 -Severity Warning `
                 -ErrorAction SilentlyContinue
-            $PSScriptAnalyzerErrors = $PSScriptAnalyzerResult | Where-Object { $_.Severity -eq 'Error' }
-            $PSScriptAnalyzerWarnings = $PSScriptAnalyzerResult | Where-Object { $_.Severity -eq 'Warning' }
+            $PSScriptAnalyzerErrors = $PSScriptAnalyzerResult `
+                | Where-Object { $_.Severity -eq 'Error' }
+            $PSScriptAnalyzerWarnings = $PSScriptAnalyzerResult `
+                | Where-Object { $_.Severity -eq 'Warning' }
             if ($PSScriptAnalyzerErrors -ne $null)
             {
-                Write-Warning -Message 'There are PSScriptAnalyzer errors that need to be fixed:'
-                @($PSScriptAnalyzerErrors).Foreach( { Write-Warning -Message "$($_.Scriptname) (Line $($_.Line)): $($_.Message)" } )
-                Write-Warning -Message  'For instructions on how to run PSScriptAnalyzer on your own machine, please go to https://github.com/powershell/psscriptAnalyzer/'
+                Write-Warning `
+                    -Message 'There are PSScriptAnalyzer errors that need to be fixed:'
+                @($PSScriptAnalyzerErrors).Foreach( {
+                    Write-Warning -Message "$($_.Scriptname) (Line $($_.Line)): $($_.Message)"
+                } )
+                Write-Warning `
+                    -Message  'For instructions on how to run PSScriptAnalyzer on your own machine, please go to https://github.com/powershell/psscriptAnalyzer/'
                 $PSScriptAnalyzerErrors.Count | Should Be $null
             }
             if ($PSScriptAnalyzerWarnings -ne $null)
             {
-                Write-Warning -Message 'There are PSScriptAnalyzer warnings that should be fixed:'
-                @($PSScriptAnalyzerWarnings).Foreach( { Write-Warning -Message "$($_.Scriptname) (Line $($_.Line)): $($_.Message)" } )
+                Write-Warning `
+                    -Message 'There are PSScriptAnalyzer warnings that should be fixed if possible:'
+                @($PSScriptAnalyzerWarnings).Foreach( {
+                    Write-Warning -Message "$($_.Scriptname) (Line $($_.Line)): $($_.Message)"
+                } )
             }
         }
     }
 }
 
 InModuleScope PSGitHub {
-
 #region Functions
 #endregion
 }
 
-Set-Location -Path $OldLocation
+Pop-Location

--- a/Tests/Unit/psgithub.tests.ps1
+++ b/Tests/Unit/psgithub.tests.ps1
@@ -14,7 +14,7 @@ if (Get-Module PSGitHub -All)
 }
 
 Import-Module "$Global:ModuleRoot\PSGitHub.psd1" -Force -DisableNameChecking
-$Global:ArtifactPath = "$Global:PSGitHub\Artifacts"
+$Global:ArtifactPath = "$Global:ModuleRoot\Artifacts"
 $null = New-Item -Path "$Global:ArtifactPath" -ItemType Directory -Force -ErrorAction SilentlyContinue
 
 # Perform PS Script Analyzer tests on module code only
@@ -23,7 +23,7 @@ $null = Install-Module -Name 'PSScriptAnalyzer' -Confirm:$False
 Import-Module -Name 'PSScriptAnalyzer'
 
 Describe 'PSScriptAnalyzer' {
-    Context 'PSGitHub Module code and Lib Functions' {
+    Context 'PSGitHub Module, Functions and TabCompleters' {
         It 'Passes Invoke-ScriptAnalyzer' {
             # Perform PSScriptAnalyzer scan.
             $PSScriptAnalyzerResult = Invoke-ScriptAnalyzer `
@@ -31,7 +31,15 @@ Describe 'PSScriptAnalyzer' {
                 -Severity Warning `
                 -ErrorAction SilentlyContinue
             $PSScriptAnalyzerResult += Invoke-ScriptAnalyzer `
-                -path "$ModuleRoot\Functions\*.ps1" `
+                -path "$ModuleRoot\Functions\Public\*.ps1" `
+                -Severity Warning `
+                -ErrorAction SilentlyContinue
+            $PSScriptAnalyzerResult += Invoke-ScriptAnalyzer `
+                -path "$ModuleRoot\Functions\Private\*.ps1" `
+                -Severity Warning `
+                -ErrorAction SilentlyContinue
+            $PSScriptAnalyzerResult += Invoke-ScriptAnalyzer `
+                -path "$ModuleRoot\TabCompleters\*.ps1" `
                 -Severity Warning `
                 -ErrorAction SilentlyContinue
             $PSScriptAnalyzerErrors = $PSScriptAnalyzerResult | Where-Object { $_.Severity -eq 'Error' }

--- a/Tests/Unit/psgithub.tests.ps1
+++ b/Tests/Unit/psgithub.tests.ps1
@@ -4,7 +4,7 @@
 # You can download Pester from http://go.microsoft.com/fwlink/?LinkID=534084
 #
 
-$ModuleRoot = "..\..\$($Script:MyInvocation.MyCommand.Path)"
+$ModuleRoot = "$($Script:MyInvocation.MyCommand.Path)\..\..\.."
 
 Push-Location `
     -Path $ModuleRoot
@@ -47,8 +47,8 @@ Describe 'PSScriptAnalyzer' {
                 -Severity Warning `
                 -ErrorAction SilentlyContinue
             $PSScriptAnalyzerResult += Invoke-ScriptAnalyzer `
-                -path "$ModuleRoot\Functions\Private\*.ps1" `
-                -Peverity Warning `
+                -Path "$ModuleRoot\Functions\Private\*.ps1" `
+                -Severity Warning `
                 -ErrorAction SilentlyContinue
             $PSScriptAnalyzerResult += Invoke-ScriptAnalyzer `
                 -Path "$ModuleRoot\TabCompleters\*.ps1" `

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,7 +71,7 @@ deploy_script:
       $null = New-Item -Path $VersionFolder -Type directory
       
       # Populate Version Folder
-      $null = Copy-Item -Path $buildFolder -Destination $VersionFolder -Recurse -Exclude '.*'
+      $null = Copy-Item -Path "$buildFolder\*" -Destination $VersionFolder -Recurse -Exclude '.*','AppVeyor.yml'
 
       # Create and Push zip Artifact
       $zipFilePath = Join-Path -Path $buildFolder -ChildPath "${env:APPVEYOR_PROJECT_NAME}_${env:APPVEYOR_BUILD_VERSION}.zip"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,7 @@ test_script:
         $testResultsFile = ".\TestsResults.xml"
         $res = Invoke-Pester -OutputFormat NUnitXml -OutputFile $testResultsFile -PassThru -ExcludeTag Incomplete
         (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $testResultsFile))
-        Get-ChildItem "$ENV:APPVEYOR_BUILD_FOLDER\PSGitHub\Artifacts\*.*" | Foreach-Object { Push-AppveyorArtifact $_ }
+        Get-ChildItem "$ENV:APPVEYOR_BUILD_FOLDER\Artifacts\*.*" | Foreach-Object { Push-AppveyorArtifact $_ }
         if ($res.FailedCount -gt 0) { 
             throw "$($res.FailedCount) tests failed."
         }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,8 +31,7 @@ install:
       # Set version number
       $ManifestContent = $ManifestContent -replace '(?<=ModuleVersion\s+=\s+'')(?<ModuleVersion>.*)(?='')', ('${{ModuleVersion}}.{0}' -f $env:APPVEYOR_BUILD_NUMBER)
       Set-Content -Path $ManifestPath -Value $ManifestContent
-      
-      Install-WindowsFeature -Name hyper-v-powershell
+
       Get-PackageProvider -Name nuget -ForceBootStrap -Force
 
 #---------------------------------# 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,7 +64,7 @@ deploy_script:
   - ps: |
       # Creating project artifact
       $buildFolder = $ENV:APPVEYOR_BUILD_FOLDER
-      $StagingFolder = Join-Path -Path $buildFolder -ChildPath 'Staging'
+      $StagingFolder = Join-Path -Path $ENV:Temp -ChildPath 'Staging'
       $null = New-Item -Path $StagingFolder -Type directory
       $ModuleFolder = Join-Path -Path $StagingFolder -ChildPath 'PSGitHub'
       $null = New-Item -Path $ModuleFolder -Type directory

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,109 @@
+﻿#---------------------------------# 
+#      environment configuration  # 
+#---------------------------------# 
+os: WMF 5
+# Don't edit this build version - only manifest version number matters.
+version: 1.0.0.{build}
+environment:
+  PowerShellGalleryApiKey:
+    secure: <ToDo>
+install: 
+  - cinst -y pester
+  - ps: |
+      # Update AppVeyor Build Version by pulling from Manifest
+      $ManifestPath = Join-Path -Path $ENV:APPVEYOR_BUILD_FOLDER -ChildPath 'PSGitHub.psd1'
+      $ManifestContent = Get-Content -Path $ManifestPath -Raw
+
+      $Regex = '(?<=ModuleVersion\s+=\s+'')(?<ModuleVersion>.*)(?='')'
+      $Matches = @([regex]::matches($ManifestContent, $Regex, 'IgnoreCase'))
+      $version = $null
+      if ($Matches)
+      {
+          $version = $Matches[0].Value
+      }
+
+      # new version
+      $version = "$version.$env:APPVEYOR_BUILD_NUMBER"
+
+      # update AppVeyor build
+      Update-AppveyorBuild -Version $version
+
+      # Set version number
+      $ManifestContent = $ManifestContent -replace '(?<=ModuleVersion\s+=\s+'')(?<ModuleVersion>.*)(?='')', ('${{ModuleVersion}}.{0}' -f $env:APPVEYOR_BUILD_NUMBER)
+      Set-Content -Path $ManifestPath -Value $ManifestContent
+      
+      Install-WindowsFeature -Name hyper-v-powershell
+      Get-PackageProvider -Name nuget -ForceBootStrap -Force
+
+#---------------------------------# 
+#      build configuration        # 
+#---------------------------------# 
+
+build: false
+
+#---------------------------------# 
+#      test configuration         # 
+#---------------------------------# 
+
+test_script:
+    - ps: |
+        $testResultsFile = ".\TestsResults.xml"
+        $res = Invoke-Pester -OutputFormat NUnitXml -OutputFile $testResultsFile -PassThru -ExcludeTag Incomplete
+        (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $testResultsFile))
+        Get-ChildItem "$ENV:APPVEYOR_BUILD_FOLDER\PSGitHub\Artifacts\*.*" | Foreach-Object { Push-AppveyorArtifact $_ }
+        if ($res.FailedCount -gt 0) { 
+            throw "$($res.FailedCount) tests failed."
+        }
+    
+#---------------------------------# 
+#      deployment configuration   # 
+#---------------------------------# 
+
+# scripts to run before deployment 
+deploy_script: 
+  - ps: |
+      # Creating project artifact
+      $buildFolder = $ENV:APPVEYOR_BUILD_FOLDER
+      $StagingFolder = Join-Path -Path $buildFolder -ChildPath 'Staging'
+      $null = New-Item -Path $StagingFolder -Type directory
+      $ModuleFolder = Join-Path -Path $StagingFolder -ChildPath 'PSGitHub'
+      $null = New-Item -Path $ModuleFolder -Type directory
+      $VersionFolder = Join-Path -Path $ModuleFolder -ChildPath $ENV:APPVEYOR_BUILD_VERSION
+      $null = New-Item -Path $VersionFolder -Type directory
+      
+      # Populate Version Folder
+      $null = Copy-Item -Path $buildFolder -Destination $VersionFolder -Recurse -Exclude '.*'
+
+      # Create and Push zip Artifact
+      $zipFilePath = Join-Path -Path $buildFolder -ChildPath "${env:APPVEYOR_PROJECT_NAME}_${env:APPVEYOR_BUILD_VERSION}.zip"
+      $null = Add-Type -assemblyname System.IO.Compression.FileSystem
+      [System.IO.Compression.ZipFile]::CreateFromDirectory($StagingFolder, $zipFilePath)
+
+      # Create and Push Script Artifact (to help manual publish of project to PSGallery)
+      $PublishScriptName = $env:APPVEYOR_PROJECT_NAME + "." + $env:APPVEYOR_BUILD_VERSION + "_publish.ps1"
+      $PublishScriptPath = Join-Path -Path $buildFolder -ChildPath $PublishScriptName
+      Set-Content -Path $PublishScriptPath -Value "Publish-Module -Name 'PSGitHub' -RequiredVersion ${env:APPVEYOR_BUILD_VERSION} -NuGetApiKey (Read-Host -Prompt 'NuGetApiKey')"
+
+      @(
+          # You can add other artifacts here
+          $zipFilePath,
+          $PublishScriptPath
+      ) | % { 
+          Write-Host "Pushing package $_ as Appveyor artifact"
+          Push-AppveyorArtifact $_
+      }
+      
+      # If this is a build of the Master branch and not a PR push
+      # then publish the Module to the PowerShell Gallery.
+      if ((! $ENV:APPVEYOR_PULL_REQUEST_NUMBER) `
+        -and ($ENV:APPVEYOR_REPO_BRANCH -eq 'master'))
+      {
+        Write-Host "Publishing Module to PowerShell Gallery"
+        Copy-Item -Path $ModuleFolder -Destination ($ENV:PSModulePath -split ';')[0] -Recurse
+        Get-PackageProvider -Name NuGet -ForceBootstrap
+        Publish-Module -Name 'PSGitHub' -RequiredVersion ${ENV:APPVEYOR_BUILD_VERSION} -NuGetApiKey $ENV:PowerShellGalleryApiKey -Confirm:$false
+      }
+      
+      # Remove Staging Folder
+      $null = Remove-Item -Path $StagingFolder -Recurse -Force
+


### PR DESCRIPTION
# Bug Fixes
- Fixes #16
  @pcgeek86: You will still need to set your encrypted API key in the AppVeyor.yml file here (on line 9):

```
environment:
  PowerShellGalleryApiKey:
    secure: <ToDo>
```
# Improvements / Enhancements
- Adds initial unit tests, which currently only run PS Script Analyzer (PSSA).
- PSSA will fail build on errors, but PSSA Warnings will **not** cause to build to fail.
- PSSA Warnings will be shown in AppVeyor console for review:
  ![2016-03-27_11-36-20](https://cloud.githubusercontent.com/assets/7589164/14062773/45a55f60-f410-11e5-83f5-282cc5972235.png)
- No other unit tests are included, but have added #Region for them to be placed.

Thanks!
