### PR TITLE
see the content...

### DIFF
--- a/Functions/Private/Invoke-GitHubApi.ps1
+++ b/Functions/Private/Invoke-GitHubApi.ps1
@@ -68,8 +68,8 @@
             $Headers.Accept = 'application/vnd.github.drax-preview+json'
         }
         
-        Write-Warning 'The API you are trying to retrive maybe preview'
-        Write-Warning 'Therefore there may be a chance that the request is unsuccessful'
+        Write-Warning -Message 'The API you are trying to retrive maybe preview'
+        Write-Warning -Message 'Therefore there may be a chance that the request is unsuccessful'
     }
 
     ### Build the REST API parameters as a HashTable for PowerShell Splatting (look it up, it's easy)
@@ -83,7 +83,7 @@
     ### Append the HTTP message body (payload), if the caller specified one.
     if ($Body) { 
         $ApiRequest.Body = $Body 
-        Write-Verbose "the request body is {0}" -f $Body
+        Write-Verbose -Message 'the request body is {0}' -f $Body
     }
 
     ### Invoke the REST API

--- a/Functions/Private/Invoke-GitHubApi.ps1
+++ b/Functions/Private/Invoke-GitHubApi.ps1
@@ -19,7 +19,7 @@
 
     .Parameter Preview
     This will retrive the preview api, 
-    by adding `application/vnd.github.drax-preview+json` to the `Accept` header.
+    by changing `Accept` header to `application/vnd.github.drax-preview+json`.
 
     .Parameter Anonymous
     If, for some reason, you need to ensure that the REST method is invoked anonymously, you can specify the
@@ -32,7 +32,7 @@
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $false)]
-        [HashTable] $Headers = @{ }
+        [HashTable] $Headers = @{Accept = application/vnd.github.v3+json}
       , [Parameter(Mandatory = $false)]
         [string] $Method = 'Get'
       , [Parameter(Mandatory = $true)]
@@ -54,7 +54,7 @@
 
     ### if the user applied Preview switch, added the header to retrive the preview api
     if ($Preview) {
-        $Headers.Add('Accept', 'application/vnd.github.drax-preview+json')
+        $Headers.Accept = application/vnd.github.drax-preview+json
         Write-Warning 'The API you are trying to retrive maybe preview'
         Write-Warning 'Therefore there may be a chance that the request is unsuccessful'
     }

--- a/Functions/Private/Invoke-GitHubApi.ps1
+++ b/Functions/Private/Invoke-GitHubApi.ps1
@@ -17,6 +17,10 @@
     This parameter is a mandatory parameter that specifies the URL part, after the API's DNS name, that
     will be invoked. By default, all
 
+    .Parameter Preview
+    This will retrive the preview api, 
+    by adding `application/vnd.github.drax-preview+json` to the `Accept` header.
+
     .Parameter Anonymous
     If, for some reason, you need to ensure that the REST method is invoked anonymously, you can specify the
     -Anonymous switch parameter. This will prevent the HTTP Authorization header from being added to the 
@@ -35,6 +39,7 @@
         [string] $RestMethod
       , [Parameter(Mandatory = $false)]
         [string] $Body
+      , [switch] $Preview
       , [switch] $Anonymous
     )
     
@@ -45,6 +50,13 @@
     if (!$Anonymous) {
         $Headers.Add('Authorization', 'Basic ' + (Get-GitHubToken).GetNetworkCredential().Password);
         Write-Verbose -Message ('Authorization header is: {0}' -f $Headers['Authorization']);
+    }
+
+    ### if the user applied Preview switch, added the header to retrive the preview api
+    if ($Preview) {
+        $Headers.Add('Accept', 'application/vnd.github.drax-preview+json')
+        Write-Warning 'The API you are trying to retrive maybe preview'
+        Write-Warning 'Therefore there may be a chance that the request is unsuccessful'
     }
 
     ### Build the REST API parameters as a HashTable for PowerShell Splatting (look it up, it's easy)

--- a/Functions/Private/Invoke-GitHubApi.ps1
+++ b/Functions/Private/Invoke-GitHubApi.ps1
@@ -32,7 +32,7 @@
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $false)]
-        [HashTable] $Headers = @{Accept = application/vnd.github.v3+json}
+        [HashTable] $Headers = @{'Accept' = 'application/vnd.github.v3+json'}
       , [Parameter(Mandatory = $false)]
         [string] $Method = 'Get'
       , [Parameter(Mandatory = $true)]

--- a/Functions/Private/Invoke-GitHubApi.ps1
+++ b/Functions/Private/Invoke-GitHubApi.ps1
@@ -48,13 +48,26 @@
     ### If the caller hasn't specified the -Anonymouse switch parameter, then add the HTTP Authorization header
     ### to authenticate the HTTP request.
     if (!$Anonymous) {
-        $Headers.Add('Authorization', 'Basic ' + (Get-GitHubToken).GetNetworkCredential().Password);
+        if (!$Headers.Authorization) {
+            $Headers.Add('Authorization', 'Basic ' + (Get-GitHubToken).GetNetworkCredential().Password)
+        }
+        else {
+            $Headers.Authorization = 'Basic ' + (Get-GitHubToken).GetNetworkCredential().Password
+        }
+
         Write-Verbose -Message ('Authorization header is: {0}' -f $Headers['Authorization']);
     }
 
     ### if the user applied Preview switch, added the header to retrive the preview api
     if ($Preview) {
-        $Headers.Accept = application/vnd.github.drax-preview+json
+
+        if (!$Headers.Accept) {
+            $Headers.Add('Accept', 'application/vnd.github.drax-preview+json')
+        }
+        else {
+            $Headers.Accept = 'application/vnd.github.drax-preview+json'
+        }
+        
         Write-Warning 'The API you are trying to retrive maybe preview'
         Write-Warning 'Therefore there may be a chance that the request is unsuccessful'
     }

--- a/Functions/Private/Invoke-GitHubApi.ps1
+++ b/Functions/Private/Invoke-GitHubApi.ps1
@@ -68,7 +68,10 @@
     Write-Verbose -Message ('Invoking the REST method: {0}' -f $ApiRequest.Uri)
         
     ### Append the HTTP message body (payload), if the caller specified one.
-    if ($Body) { $ApiRequest.Body = $Body; }
+    if ($Body) { 
+        $ApiRequest.Body = $Body 
+        Write-Verbose "the request body is {0}" -f $Body
+    }
 
     ### Invoke the REST API
     Invoke-RestMethod @ApiRequest;

--- a/Functions/Public/Get-GitHubLicense.ps1
+++ b/Functions/Public/Get-GitHubLicense.ps1
@@ -40,7 +40,7 @@ function Get-GitHubLicense
         }
         else 
         {
-            $restMethod = "licenses/{0}" -f $LicenseId
+            $restMethod = 'licenses/{0}' -f $LicenseId
         }
     }
     

--- a/Functions/Public/Get-GitHubLicense.ps1
+++ b/Functions/Public/Get-GitHubLicense.ps1
@@ -1,0 +1,51 @@
+function Get-GitHubLicense 
+{
+    <#
+    .SYNOPSIS
+        this cmdlet the the licenses that github provide
+
+    .DESCRIPTION
+        this cmdlet uses github preview api: licenses, please read https://developer.github.com/v3/licenses/ for more detail
+
+    .PARAMETER LicenseId
+        the identifier of a licenses, this is provided by GitHub and not universal
+        This is also called 'key' sometimes
+
+    .EXAMPLE
+        PS C:\> Get-GitHubLicense
+        Get all the licenses that github provided
+
+    .EXAMPLE
+        PS C:\> Get-GitHubLicense mit
+        Get the information about mit license
+
+    #>
+    [CmdletBinding()]
+    param 
+    (
+        [Parameter(Mandatory = $false, Position = 0)]
+        [string] $LicenseId
+    )
+    
+    begin 
+    {
+
+    }
+    
+    process 
+    {
+        if (-Not ($LicenseId)) 
+        {
+            $restMethod = 'licenses'
+        }
+        else 
+        {
+            $restMethod = "licenses/{0}" -f $LicenseId
+        }
+    }
+    
+    end 
+    {
+        Invoke-GitHubApi -Method get -RestMethod $restMethod -Preview
+    }
+}

--- a/PSGitHub.psd1
+++ b/PSGitHub.psd1
@@ -87,7 +87,10 @@ FunctionsToExport = @(
     'Remove-GitHubGist',
     'Get-GitHubGist',
     'Save-GitHubGist',
-    'Set-GitHubGist'
+    'Set-GitHubGist',
+
+    ### Miscellaneous
+    'Get-GitHubLicense'
     
     )
 


### PR DESCRIPTION
# Bug Fixes


- Fix a bug that when uses `Invoke-GitHubApi` with a header that already included `Authorization` that this will cause error

# Improvements / Enhancements


- Add `-preview` switch to `Invoke-GitHubApi` to enable Preview Api #29 
- Explicitly request v3 api, see: https://developer.github.com/v3/#current-version
- Add verbose output for request body, this makes debug a little easier
- Add `Get-GitHubLicense` function 

@pcgeek86 