### PR TITLE
Added support for managing release assets

### DIFF
--- a/Functions/Private/Invoke-GitHubApi.ps1
+++ b/Functions/Private/Invoke-GitHubApi.ps1
@@ -73,9 +73,13 @@
     }
 
     ### Build the REST API parameters as a HashTable for PowerShell Splatting (look it up, it's easy)
+    $LocalRestMethod = $RestMethod
+    if ($RestMethod -notlike 'https://*.github.com/*') {
+        $LocalRestMethod = "https://api.github.com/$RestMethod"
+    }
     $ApiRequest = @{
         Headers = $Headers;
-        Uri = 'https://api.github.com/{0}' -f $RestMethod;
+        Uri = $LocalRestMethod;
         Method = $Method;
     };
     Write-Verbose -Message ('Invoking the REST method: {0}' -f $ApiRequest.Uri)

--- a/Functions/Private/Invoke-GitHubApi.ps1
+++ b/Functions/Private/Invoke-GitHubApi.ps1
@@ -87,7 +87,7 @@
     ### Append the HTTP message body (payload), if the caller specified one.
     if ($Body) { 
         $ApiRequest.Body = $Body 
-        Write-Verbose -Message 'the request body is {0}' -f $Body
+        Write-Verbose -Message ('the request body is {0}' -f $Body)
     }
 
     ### Invoke the REST API

--- a/Functions/Public/Get-GitHubReleaseAsset.ps1
+++ b/Functions/Public/Get-GitHubReleaseAsset.ps1
@@ -1,0 +1,70 @@
+function Get-GitHubReleaseAsset {
+    <#
+    .SYNOPSIS
+    This command gets the github 
+
+    .DESCRIPTION
+    This command gets the assets of a release via the following 2 Parameter:
+        1. releaseid -- the release id
+        2. id -- the asset id
+
+    .PARAMETER Owner
+    the Owner of the repo to retrieve the releases, defaults to the current authenticated user.
+
+    .PARAMETER Repository
+    The repo that you want to retrieve the release
+
+    .PARAMETER ReleaseId
+    the Id of the release to retrieve, optional 
+    (cannot be used together with 'Id')
+
+    .PARAMETER Id
+    the Id of the asset to retrieve, optional 
+    (cannot be used together with 'ReleaseId')
+
+    .EXAMPLE
+    # get the all assets for a release from PowerShell/vscode-powershell 
+    C:\PS> Get-GithubReleaseAsset -Owner Powershell -Repository vscode-powershell -ReleaseId 6808217
+
+    # get a specific asset
+    C:\PS> Get-GithubReleaseAsset -Owner Powershell -Repository vscode-powershell -Id 4163551
+
+    .NOTES
+    you cannot use parameter 'ReleaseId', 'Id' together
+
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [String] $Owner,
+        [Parameter(Mandatory = $true)]
+        [string] $Repository,
+        [Parameter(Mandatory = $true, ParameterSetName = 'ReleaseId')]
+        [String] $ReleaseId,
+        [Parameter(Mandatory = $false, ParameterSetName = 'Id')]
+        [String] $Id
+    )
+    
+    begin {
+    }
+    
+    process {
+        # set the rest method
+        switch ($PSCmdlet.ParameterSetName) {
+            'ReleaseId' { $restMethod = "repos/$Owner/$Repository/releases/$ReleaseId/assets"; break; }
+            'Id' { $restMethod = "repos/$Owner/$Repository/releases/assets/$Id"; break; }
+            Default { $restMethod = "repos/$Owner/$Repository/releases/$ReleaseId/assets"; break; }
+        }
+
+        # set the API call parameter
+        $apiCall = @{
+            RestMethod = $restMethod
+            Method = 'Get'
+        }
+    }
+    
+    end {
+        # invoke the rest api call
+        Invoke-GitHubApi @apiCall
+    }
+}

--- a/Functions/Public/New-GitHubReleaseAsset.ps1
+++ b/Functions/Public/New-GitHubReleaseAsset.ps1
@@ -4,7 +4,7 @@ function New-GitHubReleaseAsset {
         Create a new GitHub release asset
     
     .DESCRIPTION
-        Create a GitHub release for a given tag and this function will not creates the tag or upload assets
+        Create a GitHub release asset for a given release
     
     .PARAMETER Owner
         Optional, the Owner of the repo that you want to create the release on, default to the authenticated user
@@ -12,30 +12,18 @@ function New-GitHubReleaseAsset {
     .PARAMETER Repository
         Mandatory, the name of the Repository that you want to create the release on.
     
-    .PARAMETER TagName
+    .PARAMETER ReleaseId
         Mandatory, the name of the tag of this release 
 
-    .PARAMETER Branch
+    .PARAMETER Path
         Optional, specify the branch of the tag, default to the default branch (usually `master`)
 
-    .PARAMETER CommitSHA
+    .PARAMETER ContentType
         Optional, the SHA of the commit that correspond to the tag
 
-    .PARAMETER Name
-        Optional, the name (title) of the release
-    
-    .PARAMETER ReleaseNote
-        Optional, the Release note of the release
-
-    .PARAMETER Draft
-        Optional, a switch to indicate whether this release is a draft release
-
-    .PARAMETER Prerelease
-        Optional, a switch to indicate whether this release is a pre-release
-
     .EXAMPLE
-        Create a new draft release in my 'test-organization/test-repo'
-        PS C:\> New-GitHubRelease -Owner 'test-organization' -Repository 'test-repo' -TagName 'v1.0' -name 'awesome release' -ReleaseNote 'great release note'
+        Create a new release asset in release with id 1234567 of project 'test-organization/test-repo'
+        PS C:\> New-GitHubRelease -Owner 'test-organization' -Repository 'test-repo' -ReleaseId 1234567 -Path .\myasset.zip
 
     .NOTES
         1. This cmdlet will not help you create a tag, you need to use git to do that.
@@ -79,7 +67,7 @@ function New-GitHubReleaseAsset {
             Body = Get-Content -Path $Path -Raw
             Headers = @{'Content-Type' = $ContentType}
             Method = 'post'
-            RestMethod = "https://uploads.github.com/repos/$Owner/$Repository/releases/$ReleaseId/assets?name=$Name"
+            RestMethod = "https://uploads.github.com/repos/$Owner/$Repository/releases/$ReleaseId/assets?name=$Name&label=$Name"
         }
     }
     

--- a/Functions/Public/New-GitHubReleaseAsset.ps1
+++ b/Functions/Public/New-GitHubReleaseAsset.ps1
@@ -1,0 +1,91 @@
+function New-GitHubReleaseAsset {
+    <#
+    .SYNOPSIS
+        Create a new GitHub release asset
+    
+    .DESCRIPTION
+        Create a GitHub release for a given tag and this function will not creates the tag or upload assets
+    
+    .PARAMETER Owner
+        Optional, the Owner of the repo that you want to create the release on, default to the authenticated user
+
+    .PARAMETER Repository
+        Mandatory, the name of the Repository that you want to create the release on.
+    
+    .PARAMETER TagName
+        Mandatory, the name of the tag of this release 
+
+    .PARAMETER Branch
+        Optional, specify the branch of the tag, default to the default branch (usually `master`)
+
+    .PARAMETER CommitSHA
+        Optional, the SHA of the commit that correspond to the tag
+
+    .PARAMETER Name
+        Optional, the name (title) of the release
+    
+    .PARAMETER ReleaseNote
+        Optional, the Release note of the release
+
+    .PARAMETER Draft
+        Optional, a switch to indicate whether this release is a draft release
+
+    .PARAMETER Prerelease
+        Optional, a switch to indicate whether this release is a pre-release
+
+    .EXAMPLE
+        Create a new draft release in my 'test-organization/test-repo'
+        PS C:\> New-GitHubRelease -Owner 'test-organization' -Repository 'test-repo' -TagName 'v1.0' -name 'awesome release' -ReleaseNote 'great release note'
+
+    .NOTES
+        1. This cmdlet will not help you create a tag, you need to use git to do that.
+        2. This cmdlet will not help you to upload assets to the release, you need to use other functions to do that
+        3. If both `Branch` and `CommitSHA` are provided, the release will be created based on the `Branch`
+        4. If a relase with the same tag already exist and it is not a draft, this method will fail
+
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [string] $Owner = (Get-GitHubAuthenticatedUser).login,
+        [Parameter(Mandatory = $true)]
+        [string] $Repository,
+        [Parameter(Mandatory = $true)]
+        [string] $ReleaseId,
+        [Parameter(Mandatory = $true)]
+        [string] $Path,
+        [Parameter(Mandatory = $false)]
+        [string] $ContentType = 'application/zip'
+    )
+    
+    begin 
+    {
+        
+    }
+    
+    process
+    {
+        ### check path of asset
+        if (-Not (Test-Path -Path $Path)) {
+            Write-Error "Failed to locate asset at $Path"
+        }
+
+        ### extract name
+        $Name = Get-Item -Path $Path | Select-Object -ExpandProperty Name
+
+        ### create a API call
+        $apiCall = 
+        @{
+            Body = Get-Content -Path $Path -Raw
+            Headers = @{'Content-Type' = $ContentType}
+            Method = 'post'
+            RestMethod = "https://uploads.github.com/repos/$Owner/$Repository/releases/$ReleaseId/assets?name=$Name"
+        }
+    }
+    
+    end
+    {
+        # invoke the api call
+        Invoke-GitHubApi @apiCall
+    }
+}

--- a/Functions/Public/Remove-GitHubReleaseAsset.ps1
+++ b/Functions/Public/Remove-GitHubReleaseAsset.ps1
@@ -1,0 +1,49 @@
+function Remove-GitHubReleaseAsset {
+    <#
+    .Synopsis
+    This command deletes a GitHub release asset.
+    
+    .Description
+    This command is responsible for deleting a GitHub release asset 
+    
+    .PARAMETER Owner
+        Optional, the Owner of the repo that you want to create the release on, default to the authenticated user
+
+    .PARAMETER Repository
+        Mandatory, the name of the Repository that you want to create the release on.
+
+    .Parameter Id
+    The Id of the Gist to remove or remove files from.
+
+    .Example
+    PS C:\> Remove-GitHubRelease -Owner 'test-organization' -Repository 'test-repo' -Id 1234567
+
+    #>
+
+    [CmdletBinding(ConfirmImpact = 'High', SupportsShouldProcess = $true)]
+    [OutputType([Void])]
+
+    Param (
+        [Parameter(Mandatory = $true)]
+        [string] $Owner,
+        [Parameter(Mandatory = $true)]
+        [string] $RepositoryName,
+        [Parameter(Mandatory = $true)]
+        [String] $Id
+    )
+    
+    Process
+    {
+        $ApiCall = @{
+            RestMethod = "repos/$Owner/$RepositoryName/releases/assets/$Id"
+            Method = 'delete'
+        }
+    }
+
+    end
+    {
+        if ($PSCmdlet.ShouldProcess($Id)) {
+            Invoke-GitHubApi @ApiCall
+        }
+    }
+}

--- a/PSGitHub.psd1
+++ b/PSGitHub.psd1
@@ -73,11 +73,16 @@ FunctionsToExport = @(
     'Get-GitHubMilestone',
     'Get-GitHubAssignee',
     'Test-GitHubAssignee',
-
+    
     ### GitHub Release commands
     'Get-GitHubRelease',
     'New-GitHubRelease',
-
+        
+    ### GitHub Release commands
+    'Get-GitHubReleaseAsset',
+    'New-GitHubReleaseAsset',
+    'Remove-GitHubReleaseAsset',
+    
     ### GitHub Fork and Pull Request commands
     'New-GitHubFork',
     'New-GitHubPullRequest',


### PR DESCRIPTION
Hi @pcgeek86,

I have implemented handling GitHub release assets for a project of mine and thought this might look nice in your module ;-)

I have added the following cmdlets:
- `Get-GitHubReleaseAsset`
- `New-GitHubReleaseAsset`
- `Remove-GitHubReleaseAsset`

To support this, it was necessary to update `Invoke-GitHubApi` to support upload.github.com for API calls.