### PR TITLE
fix possible bug with verbose output

### DIFF
--- a/Functions/Private/Invoke-GitHubApi.ps1
+++ b/Functions/Private/Invoke-GitHubApi.ps1
@@ -83,7 +83,7 @@
     ### Append the HTTP message body (payload), if the caller specified one.
     if ($Body) { 
         $ApiRequest.Body = $Body 
-        Write-Verbose -Message 'the request body is {0}' -f $Body
+        Write-Verbose -Message ('the request body is {0}' -f $Body)
     }
 
     ### Invoke the REST API


### PR DESCRIPTION
Hey @pcgeek86 I think I found (and fixed) a minor issue with `Invoke-GithubApi` (if using `-Verbose`):

```
Invoke-GitHubApi : A parameter cannot be found that matches parameter name 'f'.
At [...]\PSGithub\Functions\Public\New-GitHubRelease.ps1:128 char:9
+         Invoke-GitHubApi @apiCall
+         ~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Invoke-GitHubApi], ParameterBindingException
    + FullyQualifiedErrorId : NamedParameterNotFound,Invoke-GitHubApi
```