### PR TITLE
Modify Get-GitHubRepository to return all repos for the authenticated…

### DIFF
--- a/Functions/Public/Get-GitHubRepository.ps1
+++ b/Functions/Public/Get-GitHubRepository.ps1
@@ -5,23 +5,19 @@ function Get-GitHubRepository
         This cmdlet will get the information about a GitHub repo.
     
     .DESCRIPTION
-        This cmdlet can get the information about the github repo you specify with owner and GitHub repo name
+        This cmdlet can get the information for one or more github repos you specify with owner and GitHub repo name
         See https://developer.github.com/v3/repos/#get for detail
 
     .PARAMETER Owner
-        The owner of the repo, default to be the authenticated user
-
+        The owner of the repo, default to be the authenticated user. When used by itself, retrieves the information for all (public - unless the authenticated user is specified) repos for the specified owner.
     .PARAMETER Repository
         The name of the GitHub repository (not full name)
 
-    .PARAMETER General
-        Default switch. When this switch is turned on, you will only get the general info of the repository
-    
     .PARAMETER License
-        When this switch is turned on, you will only get the info about the license of the repository
+        When this switch is turned on, you will only get the info about the license of the repository. Can be used only when specifying the Respository Parameter.
 
     .PARAMETER ReadMe 
-        When this switch is turned on, you will only get the info about the README of the repository
+        When this switch is turned on, you will only get the info about the README of the repository. Can be used only when specifying hte Repository Parameter.
 
     .OUTPUTS
         Return a PSCustomObject. 
@@ -31,41 +27,79 @@ function Get-GitHubRepository
         PS C:\> Get-GitHubRepository -Owner octocat -Repository Hello-World
         the return of this statement is shown in https://developer.github.com/v3/repos/#get
     
+    .EXAMPLE
+        PS C:\> Get-GitHubRepository
+        Returns all respositories for the authenticated user
+
+    .EXAMPLE
+        PS C:\> Get-GitHubRepository -Owner exactmike
+        Returns all respositories for the specified user
+    
+    .EXAMPLE
+        PS C:\> Get-GitHubRepository -Owner exactmike -Repository OutSpeech -License
+        Returns the license information for the specified owner's repository
+
+    .EXAMPLE
+        PS C:\> Get-GitHubRepository -Owner exactmike -Repository OutSpeech -ReadMe
+        Returns the ReadMe information for the specified owner's repository
     #>
 
-    [CmdletBinding(DefaultParameterSetName = 'general')]
+    [CmdletBinding(DefaultParameterSetName = 'AllForOwner')]
     param(
-        [Parameter(Mandatory = $false)]
+        [Parameter(ParameterSetName = 'AllForOwner')]
+        [Parameter(Mandatory = $true,ParameterSetName = 'SpecificOwnerAndRepository')]
+        [Parameter(Mandatory = $true,ParameterSetName = 'SpecificOwnerAndRepositoryReadMe')]
+        [Parameter(Mandatory = $true,ParameterSetName = 'SpecificOwnerAndRepositoryLicense')]
         [string] $Owner = (Get-GitHubAuthenticatedUser).login,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true,ParameterSetName = 'SpecificOwnerAndRepository')]
+        [Parameter(Mandatory = $true,ParameterSetName = 'SpecificOwnerAndRepositoryReadMe')]
+        [Parameter(Mandatory = $true,ParameterSetName = 'SpecificOwnerAndRepositoryLicense')]        
         [string] $Repository,
-        [Parameter(ParameterSetName = 'license')]
+        [Parameter(Mandatory,ParameterSetName = 'SpecificOwnerAndRepositoryLicense')]
         [switch] $License,
-        [Parameter(ParameterSetName = 'readme')]
+        [Parameter(Mandatory,ParameterSetName = 'SpecificOwnerAndRepositoryReadMe')]
         [switch] $ReadMe
     )
     
     begin 
-    {
-      $restMethod = 'repos/{0}/{1}' -f $Owner, $Repository
-      
-      switch ($PSCmdlet.ParameterSetName) {
-          'license' { $restMethod += '/license'; break; }
-          'readme' { $restMethod += '/readme'; break; }
-          Default { break; }
+    { 
+      switch -Wildcard ($PSCmdlet.ParameterSetName) {
+        'AllForOwner'
+        {
+            if ($Owner -eq $(Get-GitHubAuthenticatedUser).login)
+            {
+                $RestMethod = 'user/repos'
+            }
+            else
+            {
+                $RestMethod = 'users/{0}/repos' -f $Owner
+            }
+        }
+        'SpecificOwnerAndRepository*'
+        {
+            $RestMethod = 'repos/{0}/{1}' -f $Owner, $Repository
+        }
+        'SpecificOwnerAndRepositoryReadMe'
+        {
+            $RestMethod += '/readme'
+        }
+        'SpecificOwnerAndRepositoryLicense'
+        {
+            $RestMethod += '/license'
+        }
       }
     }
-    
+
     process
     {
-        $apiCall = @{
-            RestMethod = $restMethod
+        $ApiCall = @{
+            RestMethod = $RestMethod
             Method = 'Get'
         }
     }
     
     end
     {
-        Invoke-GitHubApi @apiCall
+        Invoke-GitHubApi @ApiCall
     }
 }

--- a/PSGitHub.psd1
+++ b/PSGitHub.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PSGitHub.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.13'
+ModuleVersion = '0.14'
 
 # ID used to uniquely identify this module
 GUID = '763b7f83-ea98-4424-8e09-cd336a4c1c58'


### PR DESCRIPTION
… user when run without parameters, to return all repos for the specified owner when run with just the owner parameter and to retain consistent behavior with the ReadMe and License parameters when an owner and repository are specified.

Thanks for submitting a Pull Request to the PSGitHub project! 

# Improvements / Enhancements

List out any code changes or enhancements you've made. This includes refactoring and removal of extraneous code. :)

Modified the Get-GitHubRepository Function to return all (public and private) repositories for the authenticated user when used without parameters (Current authenticated user is still specified as the default for the Owner parameter).  Also will return all public repositories for a specified owner (it is not required to specify the Repository parameter).  Also will still return a specific repository when both owner and repository parameters are specified and will return ReadMe or License data only when those switches are used.  ParameterSets were used to retain legacy behavior and extend to the new behaviors, however, there is a change to what would happen if a user runs Get-GitHubRepository without parameters - there won't be any prompting for parameter and instead the current authenticated user's repositories would be returned.  Updated Help and Examples to match the new / modified functionality.

@pcgeek86