### PR TITLE
Adding cmdlets for manipulating labels on a repository

### DIFF
--- a/Functions/Private/Invoke-GitHubApi.ps1
+++ b/Functions/Private/Invoke-GitHubApi.ps1
@@ -9,7 +9,7 @@
 
     NOTE: Do not include the HTTP Authorization header in this HashTable, as the Authorization header
           will be set by this function.
-    
+
     .Parameter Method
     The HTTP method that will be used for the request.
 
@@ -18,12 +18,12 @@
     will be invoked. By default, all
 
     .Parameter Preview
-    This will retrive the preview api, 
+    This will retrive the preview api,
     by changing `Accept` header to `application/vnd.github.drax-preview+json`.
 
     .Parameter Anonymous
     If, for some reason, you need to ensure that the REST method is invoked anonymously, you can specify the
-    -Anonymous switch parameter. This will prevent the HTTP Authorization header from being added to the 
+    -Anonymous switch parameter. This will prevent the HTTP Authorization header from being added to the
     HTTP headers prior to invoking the REST method.
 
     .Notes
@@ -42,10 +42,10 @@
       , [switch] $Preview
       , [switch] $Anonymous
     )
-    
+
     ### TODO: Truncate leading forward slashes for the -RestMethod parameter value.
 
-    ### If the caller hasn't specified the -Anonymouse switch parameter, then add the HTTP Authorization header
+    ### If the caller hasn't specified the -Anonymous switch parameter, then add the HTTP Authorization header
     ### to authenticate the HTTP request.
     if (!$Anonymous) {
         if (!$Headers.Authorization) {
@@ -58,7 +58,7 @@
         Write-Verbose -Message ('Authorization header is: {0}' -f $Headers['Authorization']);
     }
 
-    ### if the user applied Preview switch, added the header to retrive the preview api
+    ### if the user applied Preview switch, added the header to retrieve the preview api
     if ($Preview) {
 
         if (!$Headers.Accept) {
@@ -67,7 +67,7 @@
         else {
             $Headers.Accept = 'application/vnd.github.drax-preview+json'
         }
-        
+
         Write-Warning -Message 'The API you are trying to retrive maybe preview'
         Write-Warning -Message 'Therefore there may be a chance that the request is unsuccessful'
     }
@@ -83,12 +83,15 @@
         Method = $Method;
     };
     Write-Verbose -Message ('Invoking the REST method: {0}' -f $ApiRequest.Uri)
-        
+
     ### Append the HTTP message body (payload), if the caller specified one.
-    if ($Body) { 
-        $ApiRequest.Body = $Body 
+    if ($Body) {
+        $ApiRequest.Body = $Body
         Write-Verbose -Message ('the request body is {0}' -f $Body)
     }
+
+    # We need to communicate using TLS 1.2 against GitHub.
+    [Net.ServicePointManager]::SecurityProtocol = 'tls12'
 
     ### Invoke the REST API
     Invoke-RestMethod @ApiRequest;

--- a/Functions/Private/Invoke-GitHubApi.ps1
+++ b/Functions/Private/Invoke-GitHubApi.ps1
@@ -1,7 +1,7 @@
 ﻿function Invoke-GitHubApi {
     <#
     .Synopsis
-    An internal function that is responsbile for invoking various GitHub REST methods.
+    An internal function that is responsible for invoking various GitHub REST methods.
 
     .Parameter Headers
     A HashTable of the HTTP request headers as key-value pairs. Some REST methods in the GitHub
@@ -18,7 +18,7 @@
     will be invoked. By default, all
 
     .Parameter Preview
-    This will retrive the preview api,
+    This will retrieve the preview api,
     by changing `Accept` header to `application/vnd.github.drax-preview+json`.
 
     .Parameter Anonymous
@@ -32,7 +32,7 @@
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $false)]
-        [HashTable] $Headers = @{'Accept' = 'application/vnd.github.v3+json'}
+        [HashTable] $Headers = @{Accept = 'application/vnd.github.v3+json'}
       , [Parameter(Mandatory = $false)]
         [string] $Method = 'Get'
       , [Parameter(Mandatory = $true)]
@@ -68,7 +68,7 @@
             $Headers.Accept = 'application/vnd.github.drax-preview+json'
         }
 
-        Write-Warning -Message 'The API you are trying to retrive maybe preview'
+        Write-Warning -Message 'The API you are trying to retrieve maybe preview'
         Write-Warning -Message 'Therefore there may be a chance that the request is unsuccessful'
     }
 

--- a/Functions/Public/Get-GitHubLabel.ps1
+++ b/Functions/Public/Get-GitHubLabel.ps1
@@ -1,0 +1,74 @@
+function Get-GitHubLabel {
+    <#
+    .SYNOPSIS
+    Gets GitHub labels.
+
+    .DESCRIPTION
+    This command retrieves GitHub issues either for the authenticated user or
+    from a specified repository.
+
+    .PARAMETER Owner
+    The GitHub username of the account or organization that owns the GitHub
+    repository specified in the -Repository parameter.
+
+    .PARAMETER Repository
+    Retrieve labels from the GitHub repository with the specified name,
+    owned by the GitHub user specified by -Owner.
+
+    .PARAMETER Name
+    Retrieve a single label with the specified name from the GitHub repository
+    specified by -Owner and -Repository.
+
+    .PARAMETER Page
+    The page number of the results to return. Default: 1
+    Note: The GitHub documentation of pagination warns to always rely on the
+    links provided in the response headers, rather than attempting to construct
+    the page URLs by hand. Unfortunately, as of PowerShell 5.1, Invoke-RestApi
+    does not provide access to the response headers.
+    https://developer.github.com/v3/guides/traversing-with-pagination/
+
+    .EXAMPLE
+    # Retrieve all labels from the repository Mary/WebApps:
+    Get-GitHubLabel -Owner Mary -Repository WebApps
+
+    .EXAMPLE
+    # Retrieve only the label 'Label1' from the repository Mary/WebApps:
+    Get-GitHubLabel -Owner Mary -Repository WebApps -Name Label1
+
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true, ParameterSetName = 'Repository')]
+        [Alias('User')]
+        [string] $Owner
+      , [Parameter(Mandatory = $true, ParameterSetName = 'Repository')]
+        [string] $Repository
+      , [Parameter(Mandatory = $false, ParameterSetName = 'Repository')]
+        [string] $Name
+      , [Parameter()]
+        [ValidateRange(1, [int]::MaxValue)]
+        [int] $Page
+    )
+
+    $restMethod = 'repos/{0}/{1}/labels' -f $Owner, $Repository
+
+    if ($Name) {
+        $restMethod += ("/{0}" -f $Name)
+    }
+
+    $queryParameters = @()
+    if ($Page) {
+        $queryParameters += "page=$Page"
+    }
+
+    if ($queryParameters) {
+        $restMethod += "?" + ($queryParameters -join '&')
+    }
+
+    $apiCall = @{
+        Method = 'Get';
+        RestMethod = $restMethod
+    }
+
+    Invoke-GitHubApi @apiCall
+}

--- a/Functions/Public/Get-GitHubLabel.ps1
+++ b/Functions/Public/Get-GitHubLabel.ps1
@@ -66,6 +66,9 @@ function Get-GitHubLabel {
     }
 
     $apiCall = @{
+        Headers =  @{
+            'Accept' = 'application/vnd.github.symmetra-preview+json'
+        }
         Method = 'Get'
         RestMethod = $restMethod
     }

--- a/Functions/Public/Get-GitHubLabel.ps1
+++ b/Functions/Public/Get-GitHubLabel.ps1
@@ -67,7 +67,7 @@ function Get-GitHubLabel {
 
     $apiCall = @{
         Headers =  @{
-            'Accept' = 'application/vnd.github.symmetra-preview+json'
+            Accept = 'application/vnd.github.symmetra-preview+json'
         }
         Method = 'Get'
         RestMethod = $restMethod

--- a/Functions/Public/Get-GitHubLabel.ps1
+++ b/Functions/Public/Get-GitHubLabel.ps1
@@ -4,20 +4,20 @@ function Get-GitHubLabel {
     Gets GitHub labels.
 
     .DESCRIPTION
-    This command retrieves GitHub issues either for the authenticated user or
-    from a specified repository.
+    This command retrieves GitHub labels for the specified repository using
+    the authenticated user.
 
     .PARAMETER Owner
     The GitHub username of the account or organization that owns the GitHub
-    repository specified in the -Repository parameter.
+    repository specified in the parameter -Repository parameter.
 
     .PARAMETER Repository
-    Retrieve labels from the GitHub repository with the specified name,
-    owned by the GitHub user specified by -Owner.
+    The name of the GitHub repository, that is owned by the GitHub username
+    specified by parameter -Owner.
 
     .PARAMETER Name
     Retrieve a single label with the specified name from the GitHub repository
-    specified by -Owner and -Repository.
+    specified by the parameters -Owner and -Repository.
 
     .PARAMETER Page
     The page number of the results to return. Default: 1

--- a/Functions/Public/Get-GitHubLabel.ps1
+++ b/Functions/Public/Get-GitHubLabel.ps1
@@ -66,7 +66,7 @@ function Get-GitHubLabel {
     }
 
     $apiCall = @{
-        Method = 'Get';
+        Method = 'Get'
         RestMethod = $restMethod
     }
 

--- a/Functions/Public/New-GitHubLabel.ps1
+++ b/Functions/Public/New-GitHubLabel.ps1
@@ -1,0 +1,91 @@
+function New-GitHubLabel {
+    <#
+    .SYNOPSIS
+    Create a GitHub label.
+
+    .DESCRIPTION
+    This command creates a GitHub label in the specified repository using
+    the authenticated user.
+
+    .PARAMETER Owner
+    The GitHub username of the account or organization that owns the GitHub
+    repository specified in the parameter -Repository parameter.
+
+    .PARAMETER Repository
+    The name of the GitHub repository, that is owned by the GitHub username
+    specified by parameter -Owner.
+
+    .PARAMETER Name
+    The name of the label to create in the GitHub repository specified by the
+    parameters -Owner and -Repository.
+    It is possible to add emoji to label names, i.e. 'Good :strawberry:'.
+
+    .PARAMETER Color
+    The color of the label that is specified by the parameter -Name.
+    The color should be specified without the leading '#'.
+
+   .PARAMETER Description
+    The description of the label that is specified by the parameter -Name.
+    GitHub has limited the description to max 100 characters.
+
+    .PARAMETER Force
+    Forces the execution without confirmation prompts.
+
+    .EXAMPLE
+    # Create a label without description.
+    New-GitHubLabel -Owner Mary -Repository WebApps -Name 'good first issue' -Color '5319e7'
+
+    .EXAMPLE
+    # Create a label without description using emoji.
+    New-GitHubLabel -Owner Mary -Repository WebApps -Name 'Good :strawberry:' -Color 'ffffff'
+
+    .EXAMPLE
+    # Create a label with a description.
+    New-GitHubLabel -Owner Mary -Repository WebApps -Name 'good first issue' -Color '5319e7' -Description 'The issue should be easier to fix and can be taken up by a beginner to learn to contribute on GitHub.'
+
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    param (
+        [Parameter(Mandatory = $true, ParameterSetName = 'Repository')]
+        [Alias('User')]
+        [string] $Owner
+      , [Parameter(Mandatory = $true, ParameterSetName = 'Repository')]
+        [string] $Repository
+      , [Parameter(Mandatory = $true, ParameterSetName = 'Repository')]
+        [string] $Name
+      , [Parameter(Mandatory = $true, ParameterSetName = 'Repository')]
+        [string] $Color
+      , [Parameter(Mandatory = $false, ParameterSetName = 'Repository')]
+        [string] $Description
+      , [Parameter()]
+        [switch] $Force
+    )
+
+    $shouldProcessCaption = 'Creating new GitHub label'
+    $shouldProcessDescription = 'Creating the GitHub label ''{0}'' in the repository ''{1}/{2}''.' -f $Name, $Owner, $Repository
+    $shouldProcessWarning = 'Do you want to create the GitHub label ''{0}'' in the repository ''{1}/{2}''?' -f $Name, $Owner, $Repository
+
+    if ($Force -or $PSCmdlet.ShouldProcess($shouldProcessDescription, $shouldProcessWarning, $shouldProcessCaption)) {
+        $restMethod = 'repos/{0}/{1}/labels' -f $Owner, $Repository
+
+        $bodyProperties = @{
+            name = $Name
+            color = $Color
+        }
+
+        if ($Description) {
+            $bodyProperties['description'] = $Description
+        }
+
+        $apiCall = @{
+            Method = 'Post'
+            RestMethod = $restMethod
+            Body = $bodyProperties | ConvertTo-Json
+        }
+
+        # Variable scope ensures that parent session remains unchanged
+        $ConfirmPreference = 'None'
+
+        Invoke-GitHubApi @apiCall
+    }
+}

--- a/Functions/Public/New-GitHubLabel.ps1
+++ b/Functions/Public/New-GitHubLabel.ps1
@@ -78,6 +78,9 @@ function New-GitHubLabel {
         }
 
         $apiCall = @{
+            Headers =  @{
+                'Accept' = 'application/vnd.github.symmetra-preview+json'
+            }
             Method = 'Post'
             RestMethod = $restMethod
             Body = $bodyProperties | ConvertTo-Json

--- a/Functions/Public/New-GitHubLabel.ps1
+++ b/Functions/Public/New-GitHubLabel.ps1
@@ -79,7 +79,7 @@ function New-GitHubLabel {
 
         $apiCall = @{
             Headers =  @{
-                'Accept' = 'application/vnd.github.symmetra-preview+json'
+                Accept = 'application/vnd.github.symmetra-preview+json'
             }
             Method = 'Post'
             RestMethod = $restMethod

--- a/Functions/Public/Remove-GitHubLabel.ps1
+++ b/Functions/Public/Remove-GitHubLabel.ps1
@@ -49,7 +49,7 @@ function Remove-GitHubLabel {
 
         $apiCall = @{
             Headers =  @{
-                'Accept' = 'application/vnd.github.symmetra-preview+json'
+                Accept = 'application/vnd.github.symmetra-preview+json'
             }
             Method = 'Delete'
             RestMethod = $restMethod

--- a/Functions/Public/Remove-GitHubLabel.ps1
+++ b/Functions/Public/Remove-GitHubLabel.ps1
@@ -1,0 +1,63 @@
+function Remove-GitHubLabel {
+    <#
+    .SYNOPSIS
+    Remove a GitHub label.
+
+    .DESCRIPTION
+    This command removes a GitHub label from the specified repository using
+    the authenticated user.
+
+    .PARAMETER Owner
+    The GitHub username of the account or organization that owns the GitHub
+    repository specified in the parameter -Repository parameter.
+
+    .PARAMETER Repository
+    The name of the GitHub repository, that is owned by the GitHub username
+    specified by parameter -Owner.
+
+    .PARAMETER Name
+    The name of the label to remove from the GitHub repository specified by the
+    parameters -Owner and -Repository.
+
+    .PARAMETER Force
+    Forces the execution without confirmation prompts.
+
+    .EXAMPLE
+    # date the label name.
+    Remove-GitHubLabel -Owner Mary -Repository WebApps -Name 'Label1'
+
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+    param (
+        [Parameter(Mandatory = $true, ParameterSetName = 'Repository')]
+        [Alias('User')]
+        [string] $Owner
+      , [Parameter(Mandatory = $true, ParameterSetName = 'Repository')]
+        [string] $Repository
+      , [Parameter(Mandatory = $true, ParameterSetName = 'Repository')]
+        [string] $Name
+      , [Parameter()]
+        [switch] $Force
+    )
+
+    $shouldProcessCaption = 'Remove an existing GitHub label'
+    $shouldProcessDescription = 'Removing the GitHub label ''{0}'' in the repository ''{1}/{2}''.' -f $Name, $Owner, $Repository
+    $shouldProcessWarning = 'Do you want to remove the GitHub label ''{0}'' in the repository ''{1}/{2}''?' -f $Name, $Owner, $Repository
+
+    if ($Force -or $PSCmdlet.ShouldProcess($shouldProcessDescription, $shouldProcessWarning, $shouldProcessCaption)) {
+        $restMethod = 'repos/{0}/{1}/labels/{2}' -f $Owner, $Repository, $Name
+
+        $apiCall = @{
+            Headers =  @{
+                'Accept' = 'application/vnd.github.symmetra-preview+json'
+            }
+            Method = 'Delete'
+            RestMethod = $restMethod
+        }
+
+        # Variable scope ensures that parent session remains unchanged
+        $ConfirmPreference = 'None'
+
+        Invoke-GitHubApi @apiCall
+    }
+}

--- a/Functions/Public/Set-GitHubLabel.ps1
+++ b/Functions/Public/Set-GitHubLabel.ps1
@@ -1,0 +1,108 @@
+function Set-GitHubLabel {
+    <#
+    .SYNOPSIS
+    Update a GitHub label.
+
+    .DESCRIPTION
+    This command updates a GitHub label in the specified repository using
+    the authenticated user.
+
+    .PARAMETER Owner
+    The GitHub username of the account or organization that owns the GitHub
+    repository specified in the parameter -Repository parameter.
+
+    .PARAMETER Repository
+    The name of the GitHub repository, that is owned by the GitHub username
+    specified by parameter -Owner.
+
+    .PARAMETER Name
+    The name of the label to update in the GitHub repository specified by the
+    parameters -Owner and -Repository.
+
+    .PARAMETER NewName
+    The new name of the label that is specified by the parameter -Name.
+    It is possible to add emoji to label names, i.e. 'Good :strawberry:'.
+
+    .PARAMETER Color
+    The new color of the label that is specified by the parameter -Name.
+    The color should be specified without the leading '#'.
+
+   .PARAMETER Description
+    The new description of the label that is specified by the parameter -Name.
+    GitHub has limited the description to max 100 characters.
+
+    .PARAMETER Force
+    Forces the execution without confirmation prompts.
+
+    .EXAMPLE
+    # Update the label name.
+    Set-GitHubLabel -Owner Mary -Repository WebApps -Name 'Label1' -NewName 'NewLabelName'
+
+    .EXAMPLE
+    # Update the label color.
+    Set-GitHubLabel -Owner Mary -Repository WebApps -Name 'good first issue' -Color '5319e7'
+
+    .EXAMPLE
+    # Update the label description.
+    New-GitHubLabel -Owner Mary -Repository WebApps -Name 'good first issue' -Description 'The issue should be easier to fix and can be taken up by a beginner to learn to contribute on GitHub.'
+
+    .EXAMPLE
+    # Update all the label properties at the same time.
+    New-GitHubLabel -Owner Mary -Repository WebApps -Name 'Label1' -NewName 'NewLabelName' -Color '5319e7' -Description 'Label description'
+
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+    param (
+        [Parameter(Mandatory = $true, ParameterSetName = 'Repository')]
+        [Alias('User')]
+        [string] $Owner
+      , [Parameter(Mandatory = $true, ParameterSetName = 'Repository')]
+        [string] $Repository
+      , [Parameter(Mandatory = $true, ParameterSetName = 'Repository')]
+        [string] $Name
+      , [Parameter(Mandatory = $false, ParameterSetName = 'Repository')]
+        [string] $NewName
+      , [Parameter(Mandatory = $false, ParameterSetName = 'Repository')]
+        [string] $Color
+      , [Parameter(Mandatory = $false, ParameterSetName = 'Repository')]
+        [string] $Description
+      , [Parameter()]
+        [switch] $Force
+    )
+
+    $shouldProcessCaption = 'Updating an existing GitHub label'
+    $shouldProcessDescription = 'Updating the GitHub label ''{0}'' in the repository ''{1}/{2}''.' -f $Name, $Owner, $Repository
+    $shouldProcessWarning = 'Do you want to update the GitHub label ''{0}'' in the repository ''{1}/{2}''?' -f $Name, $Owner, $Repository
+
+    if ($Force -or $PSCmdlet.ShouldProcess($shouldProcessDescription, $shouldProcessWarning, $shouldProcessCaption)) {
+        $restMethod = 'repos/{0}/{1}/labels/{2}' -f $Owner, $Repository, $Name
+
+        $bodyProperties = @{}
+
+        if ($NewName) {
+            $bodyProperties['name'] = $NewName
+        }
+
+        if ($Color) {
+            $bodyProperties['color'] = $Color
+        }
+
+        if ($Description) {
+            $bodyProperties['description'] = $Description
+        }
+
+        $apiCall = @{
+            Headers =  @{
+                'Accept' = 'application/vnd.github.symmetra-preview+json'
+            }
+            Method = 'Post'
+            RestMethod = $restMethod
+            Body = $bodyProperties | ConvertTo-Json
+        }
+
+        # Variable scope ensures that parent session remains unchanged
+        $ConfirmPreference = 'None'
+
+        Invoke-GitHubApi @apiCall
+    }
+}

--- a/Functions/Public/Set-GitHubLabel.ps1
+++ b/Functions/Public/Set-GitHubLabel.ps1
@@ -93,7 +93,7 @@ function Set-GitHubLabel {
 
         $apiCall = @{
             Headers =  @{
-                'Accept' = 'application/vnd.github.symmetra-preview+json'
+                Accept = 'application/vnd.github.symmetra-preview+json'
             }
             Method = 'Patch'
             RestMethod = $restMethod

--- a/Functions/Public/Set-GitHubLabel.ps1
+++ b/Functions/Public/Set-GitHubLabel.ps1
@@ -95,7 +95,7 @@ function Set-GitHubLabel {
             Headers =  @{
                 'Accept' = 'application/vnd.github.symmetra-preview+json'
             }
-            Method = 'Post'
+            Method = 'Patch'
             RestMethod = $restMethod
             Body = $bodyProperties | ConvertTo-Json
         }

--- a/PSGitHub.psd1
+++ b/PSGitHub.psd1
@@ -103,6 +103,7 @@ FunctionsToExport = @(
     'Get-GitHubLabel',
     'New-GitHubLabel',
     'Set-GitHubLabel',
+    'Remove-GitHubLabel',
 
     ### Miscellaneous
     'Get-GitHubLicense'

--- a/PSGitHub.psd1
+++ b/PSGitHub.psd1
@@ -102,6 +102,7 @@ FunctionsToExport = @(
     ### GitHub label commands
     'Get-GitHubLabel',
     'New-GitHubLabel',
+    'Set-GitHubLabel',
 
     ### Miscellaneous
     'Get-GitHubLicense'

--- a/PSGitHub.psd1
+++ b/PSGitHub.psd1
@@ -101,6 +101,7 @@ FunctionsToExport = @(
 
     ### GitHub label commands
     'Get-GitHubLabel',
+    'New-GitHubLabel',
 
     ### Miscellaneous
     'Get-GitHubLicense'

--- a/PSGitHub.psd1
+++ b/PSGitHub.psd1
@@ -78,16 +78,16 @@ FunctionsToExport = @(
     ### GitHub Comment commands
     'Get-GitHubComment',
     'New-GitHubComment',
-    
+
     ### GitHub Release commands
     'Get-GitHubRelease',
     'New-GitHubRelease',
-        
+
     ### GitHub Release commands
     'Get-GitHubReleaseAsset',
     'New-GitHubReleaseAsset',
     'Remove-GitHubReleaseAsset',
-    
+
     ### GitHub Fork and Pull Request commands
     'New-GitHubFork',
     'New-GitHubPullRequest',
@@ -99,9 +99,12 @@ FunctionsToExport = @(
     'Save-GitHubGist',
     'Set-GitHubGist',
 
+    ### GitHub label commands
+    'Get-GitHubLabel',
+
     ### Miscellaneous
     'Get-GitHubLicense'
-    
+
     )
 
 # Cmdlets to export from this module

--- a/Tests/Unit/psgithub.tests.ps1
+++ b/Tests/Unit/psgithub.tests.ps1
@@ -324,6 +324,55 @@ InModuleScope PSGitHub {
             }
         }
     }
+
+    Describe 'Remove-GitHubLabel' {
+        BeforeAll {
+            Mock -CommandName Invoke-GitHubApi
+
+            $mockOwnerName = 'Mary'
+            $mockRepositoryName = 'WebApps'
+            $mockLabelName = 'Label1'
+
+            $newGitHubLabelParameters = @{
+                Owner = $mockOwnerName
+                Repository = $mockRepositoryName
+                Name = $mockLabelName
+            }
+
+            $mockExpectedDefaultRestMethod = 'repos/{0}/{1}/labels/{2}' -f $mockOwnerName, $mockRepositoryName, $mockLabelName
+        }
+
+        Context 'When removing a label' {
+            It 'Should call the mock with the correct arguments' {
+                { Remove-GitHubLabel @newGitHubLabelParameters -Confirm:$false } | Should -Not -Throw
+
+                Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 1 -ParameterFilter {
+                    $Method -eq 'Delete' `
+                    -and $RestMethod -eq $mockExpectedDefaultRestMethod `
+                    -and $null -eq $Body
+                }
+            }
+        }
+
+        Context 'When removing a label and requesting explicit validation' {
+            It 'Should not not call any mock' {
+                { Remove-GitHubLabel @newGitHubLabelParameters -WhatIf } | Should -Not -Throw
+
+                Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 0
+            }
+        }
+
+        Context 'When removing a label and requesting to forcibly execute' {
+            It 'Should call the correct mock' {
+                {
+                    $ConfirmPreference = 'Medium'
+                    Remove-GitHubLabel @newGitHubLabelParameters -Force
+                } | Should -Not -Throw
+
+                Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 1
+            }
+        }
+    }
     #endregion
 }
 

--- a/Tests/Unit/psgithub.tests.ps1
+++ b/Tests/Unit/psgithub.tests.ps1
@@ -101,8 +101,8 @@ InModuleScope PSGitHub {
                 { Get-GitHubLabel -Owner $mockOwnerName -Repository $mockRepositoryName } | Should -Not -Throw
 
                 Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 1 -ParameterFilter {
-                    $Method -eq 'Get' `
-                    -and $RestMethod -eq $mockExpectedDefaultRestMethod
+                    $Method -eq 'Get' -and
+                    $RestMethod -eq $mockExpectedDefaultRestMethod
                 }
             }
         }
@@ -112,8 +112,8 @@ InModuleScope PSGitHub {
                 { Get-GitHubLabel -Owner $mockOwnerName -Repository $mockRepositoryName -Page 2 } | Should -Not -Throw
 
                 Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 1 -ParameterFilter {
-                    $Method -eq 'Get' `
-                    -and $RestMethod -eq ('{0}?page=2' -f $mockExpectedDefaultRestMethod)
+                    $Method -eq 'Get' -and
+                    $RestMethod -eq ('{0}?page=2' -f $mockExpectedDefaultRestMethod)
                 }
             }
         }
@@ -123,8 +123,8 @@ InModuleScope PSGitHub {
                 { Get-GitHubLabel -Owner $mockOwnerName -Repository $mockRepositoryName -Name $mockLabelName } | Should -Not -Throw
 
                 Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 1 -ParameterFilter {
-                    $Method -eq 'Get' `
-                    -and $RestMethod -eq ('{0}/{1}' -f $mockExpectedDefaultRestMethod, $mockLabelName)
+                    $Method -eq 'Get' -and
+                    $RestMethod -eq ('{0}/{1}' -f $mockExpectedDefaultRestMethod, $mockLabelName)
                 }
             }
         }
@@ -160,9 +160,9 @@ InModuleScope PSGitHub {
                 { New-GitHubLabel @newGitHubLabelParameters -Confirm:$false } | Should -Not -Throw
 
                 Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 1 -ParameterFilter {
-                    $Method -eq 'Post' `
-                    -and $RestMethod -eq $mockExpectedDefaultRestMethod `
-                    -and $Body -eq ($mockExpectedDefaultRequestBody | ConvertTo-Json)
+                    $Method -eq 'Post' -and
+                    $RestMethod -eq $mockExpectedDefaultRestMethod -and
+                    $Body -eq ($mockExpectedDefaultRequestBody | ConvertTo-Json)
                 }
             }
         }
@@ -178,9 +178,9 @@ InModuleScope PSGitHub {
                 $mockExpectedRequestBody['description'] = $mockLabelDescription
 
                 Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 1 -ParameterFilter {
-                    $Method -eq 'Post' `
-                    -and $RestMethod -eq $mockExpectedDefaultRestMethod `
-                    -and $Body -eq ($mockExpectedRequestBody | ConvertTo-Json)
+                    $Method -eq 'Post' -and
+                    $RestMethod -eq $mockExpectedDefaultRestMethod -and
+                    $Body -eq ($mockExpectedRequestBody | ConvertTo-Json)
                 }
             }
         }
@@ -237,9 +237,9 @@ InModuleScope PSGitHub {
                 }
 
                 Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 1 -ParameterFilter {
-                    $Method -eq 'Patch' `
-                    -and $RestMethod -eq $mockExpectedDefaultRestMethod `
-                    -and $Body -eq ($mockExpectedRequestBody | ConvertTo-Json)
+                    $Method -eq 'Patch' -and
+                    $RestMethod -eq $mockExpectedDefaultRestMethod -and
+                    $Body -eq ($mockExpectedRequestBody | ConvertTo-Json)
                 }
             }
         }
@@ -256,9 +256,9 @@ InModuleScope PSGitHub {
                 }
 
                 Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 1 -ParameterFilter {
-                    $Method -eq 'Patch' `
-                    -and $RestMethod -eq $mockExpectedDefaultRestMethod `
-                    -and $Body -eq ($mockExpectedRequestBody | ConvertTo-Json)
+                    $Method -eq 'Patch' -and
+                    $RestMethod -eq $mockExpectedDefaultRestMethod -and
+                    $Body -eq ($mockExpectedRequestBody | ConvertTo-Json)
                 }
             }
         }
@@ -275,9 +275,9 @@ InModuleScope PSGitHub {
                 }
 
                 Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 1 -ParameterFilter {
-                    $Method -eq 'Patch' `
-                    -and $RestMethod -eq $mockExpectedDefaultRestMethod `
-                    -and $Body -eq ($mockExpectedRequestBody | ConvertTo-Json)
+                    $Method -eq 'Patch' -and
+                    $RestMethod -eq $mockExpectedDefaultRestMethod -and
+                    $Body -eq ($mockExpectedRequestBody | ConvertTo-Json)
                 }
             }
         }
@@ -298,9 +298,9 @@ InModuleScope PSGitHub {
                 }
 
                 Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 1 -ParameterFilter {
-                    $Method -eq 'Patch' `
-                    -and $RestMethod -eq $mockExpectedDefaultRestMethod `
-                    -and $Body -eq ($mockExpectedRequestBody | ConvertTo-Json)
+                    $Method -eq 'Patch' -and
+                    $RestMethod -eq $mockExpectedDefaultRestMethod -and
+                    $Body -eq ($mockExpectedRequestBody | ConvertTo-Json)
                 }
             }
         }
@@ -347,9 +347,9 @@ InModuleScope PSGitHub {
                 { Remove-GitHubLabel @newGitHubLabelParameters -Confirm:$false } | Should -Not -Throw
 
                 Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 1 -ParameterFilter {
-                    $Method -eq 'Delete' `
-                    -and $RestMethod -eq $mockExpectedDefaultRestMethod `
-                    -and $null -eq $Body
+                    $Method -eq 'Delete' -and
+                    $RestMethod -eq $mockExpectedDefaultRestMethod -and
+                    $null -eq $Body
                 }
             }
         }

--- a/Tests/Unit/psgithub.tests.ps1
+++ b/Tests/Unit/psgithub.tests.ps1
@@ -84,8 +84,50 @@ Describe 'PSScriptAnalyzer' {
 }
 
 InModuleScope PSGitHub {
-#region Functions
-#endregion
+    #region *-GitHubLabel
+    Describe 'Get-GitHubLabel' {
+        BeforeAll {
+            Mock -CommandName Invoke-GitHubApi
+
+            $mockOwnerName = 'Mary'
+            $mockRepositoryName = 'WebApps'
+            $mockLabelName = 'Label1'
+        }
+
+        Context 'When getting first page of all labels in a repository' {
+            It 'Should call the mock with the correct arguments' {
+                { Get-GitHubLabel -Owner $mockOwnerName -Repository $mockRepositoryName } | Should -Not -Throw
+
+                Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 1 -ParameterFilter {
+                    $Method -eq 'Get' `
+                    -and $RestMethod -eq ('repos/{0}/{1}/labels' -f $mockOwnerName, $mockRepositoryName)
+                }
+            }
+        }
+
+        Context 'When getting second page of all labels in a repository' {
+            It 'Should call the mock with the correct arguments' {
+                { Get-GitHubLabel -Owner $mockOwnerName -Repository $mockRepositoryName -Page 2 } | Should -Not -Throw
+
+                Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 1 -ParameterFilter {
+                    $Method -eq 'Get' `
+                    -and $RestMethod -eq ('repos/{0}/{1}/labels?page=2' -f $mockOwnerName, $mockRepositoryName)
+                }
+            }
+        }
+
+        Context 'When getting a specific label in a repository' {
+            It 'Should call the mock with the correct arguments' {
+                { Get-GitHubLabel -Owner $mockOwnerName -Repository $mockRepositoryName -Name $mockLabelName } | Should -Not -Throw
+
+                Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 1 -ParameterFilter {
+                    $Method -eq 'Get' `
+                    -and $RestMethod -eq ('repos/{0}/{1}/labels/{2}' -f $mockOwnerName, $mockRepositoryName, $mockLabelName)
+                }
+            }
+        }
+    }
+    #endregion
 }
 
 Pop-Location

--- a/Tests/Unit/psgithub.tests.ps1
+++ b/Tests/Unit/psgithub.tests.ps1
@@ -237,7 +237,7 @@ InModuleScope PSGitHub {
                 }
 
                 Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 1 -ParameterFilter {
-                    $Method -eq 'Post' `
+                    $Method -eq 'Patch' `
                     -and $RestMethod -eq $mockExpectedDefaultRestMethod `
                     -and $Body -eq ($mockExpectedRequestBody | ConvertTo-Json)
                 }
@@ -256,7 +256,7 @@ InModuleScope PSGitHub {
                 }
 
                 Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 1 -ParameterFilter {
-                    $Method -eq 'Post' `
+                    $Method -eq 'Patch' `
                     -and $RestMethod -eq $mockExpectedDefaultRestMethod `
                     -and $Body -eq ($mockExpectedRequestBody | ConvertTo-Json)
                 }
@@ -275,7 +275,7 @@ InModuleScope PSGitHub {
                 }
 
                 Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 1 -ParameterFilter {
-                    $Method -eq 'Post' `
+                    $Method -eq 'Patch' `
                     -and $RestMethod -eq $mockExpectedDefaultRestMethod `
                     -and $Body -eq ($mockExpectedRequestBody | ConvertTo-Json)
                 }
@@ -298,7 +298,7 @@ InModuleScope PSGitHub {
                 }
 
                 Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 1 -ParameterFilter {
-                    $Method -eq 'Post' `
+                    $Method -eq 'Patch' `
                     -and $RestMethod -eq $mockExpectedDefaultRestMethod `
                     -and $Body -eq ($mockExpectedRequestBody | ConvertTo-Json)
                 }

--- a/Tests/Unit/psgithub.tests.ps1
+++ b/Tests/Unit/psgithub.tests.ps1
@@ -170,7 +170,7 @@ InModuleScope PSGitHub {
         Context 'When adding a new label without description' {
             It 'Should call the mock with the correct arguments' {
                 $mockTestParameters = $newGitHubLabelParameters.Clone()
-                $mockTestParameters['description'] = $mockLabelDescription
+                $mockTestParameters['Description'] = $mockLabelDescription
 
                 { New-GitHubLabel @mockTestParameters -Confirm:$false } | Should -Not -Throw
 
@@ -198,6 +198,126 @@ InModuleScope PSGitHub {
                 {
                     $ConfirmPreference = 'Medium'
                     New-GitHubLabel @newGitHubLabelParameters -Force
+                } | Should -Not -Throw
+
+                Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 1
+            }
+        }
+    }
+
+    Describe 'Set-GitHubLabel' {
+        BeforeAll {
+            Mock -CommandName Invoke-GitHubApi
+
+            $mockOwnerName = 'Mary'
+            $mockRepositoryName = 'WebApps'
+            $mockLabelName = 'Label1'
+            $mockNewLabelName = 'NewName'
+            $mockLabelColor = 'ffffff'
+            $mockLabelDescription = 'Label description'
+
+            $newGitHubLabelParameters = @{
+                Owner = $mockOwnerName
+                Repository = $mockRepositoryName
+                Name = $mockLabelName
+            }
+
+            $mockExpectedDefaultRestMethod = 'repos/{0}/{1}/labels/{2}' -f $mockOwnerName, $mockRepositoryName, $mockLabelName
+        }
+
+        Context 'When updating a label with a new name' {
+            It 'Should call the mock with the correct arguments' {
+                $mockTestParameters = $newGitHubLabelParameters.Clone()
+                $mockTestParameters['NewName'] = $mockNewLabelName
+
+                { Set-GitHubLabel @mockTestParameters -Confirm:$false } | Should -Not -Throw
+
+                $mockExpectedRequestBody = @{
+                    name = $mockNewLabelName
+                }
+
+                Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 1 -ParameterFilter {
+                    $Method -eq 'Post' `
+                    -and $RestMethod -eq $mockExpectedDefaultRestMethod `
+                    -and $Body -eq ($mockExpectedRequestBody | ConvertTo-Json)
+                }
+            }
+        }
+
+        Context 'When updating a label with a new color' {
+            It 'Should call the mock with the correct arguments' {
+                $mockTestParameters = $newGitHubLabelParameters.Clone()
+                $mockTestParameters['Color'] = $mockLabelColor
+
+                { Set-GitHubLabel @mockTestParameters -Confirm:$false } | Should -Not -Throw
+
+                $mockExpectedRequestBody = @{
+                    color = $mockLabelColor
+                }
+
+                Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 1 -ParameterFilter {
+                    $Method -eq 'Post' `
+                    -and $RestMethod -eq $mockExpectedDefaultRestMethod `
+                    -and $Body -eq ($mockExpectedRequestBody | ConvertTo-Json)
+                }
+            }
+        }
+
+        Context 'When updating a label with a new description' {
+            It 'Should call the mock with the correct arguments' {
+                $mockTestParameters = $newGitHubLabelParameters.Clone()
+                $mockTestParameters['Description'] = $mockLabelDescription
+
+                { Set-GitHubLabel @mockTestParameters -Confirm:$false } | Should -Not -Throw
+
+                $mockExpectedRequestBody = @{
+                    description = $mockLabelDescription
+                }
+
+                Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 1 -ParameterFilter {
+                    $Method -eq 'Post' `
+                    -and $RestMethod -eq $mockExpectedDefaultRestMethod `
+                    -and $Body -eq ($mockExpectedRequestBody | ConvertTo-Json)
+                }
+            }
+        }
+
+        Context 'When updating a label with a new name, color and description' {
+            It 'Should call the mock with the correct arguments' {
+                $mockTestParameters = $newGitHubLabelParameters.Clone()
+                $mockTestParameters['NewName'] = $mockNewLabelName
+                $mockTestParameters['Color'] = $mockLabelColor
+                $mockTestParameters['Description'] = $mockLabelDescription
+
+                { Set-GitHubLabel @mockTestParameters -Confirm:$false } | Should -Not -Throw
+
+                $mockExpectedRequestBody = @{
+                    name = $mockNewLabelName
+                    color = $mockLabelColor
+                    description = $mockLabelDescription
+                }
+
+                Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 1 -ParameterFilter {
+                    $Method -eq 'Post' `
+                    -and $RestMethod -eq $mockExpectedDefaultRestMethod `
+                    -and $Body -eq ($mockExpectedRequestBody | ConvertTo-Json)
+                }
+            }
+        }
+
+        Context 'When adding a new label and requesting explicit validation' {
+            It 'Should not not call any mock' {
+                { Set-GitHubLabel @newGitHubLabelParameters -WhatIf } | Should -Not -Throw
+
+                Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 0
+            }
+        }
+
+        Context 'When adding a new label and requesting to forcibly execute' {
+            It 'Should call the correct mock' {
+                {
+                    $ConfirmPreference = 'Medium'
+                    Set-GitHubLabel @newGitHubLabelParameters -Force
                 } | Should -Not -Throw
 
                 Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 1

--- a/Tests/Unit/psgithub.tests.ps1
+++ b/Tests/Unit/psgithub.tests.ps1
@@ -1,6 +1,6 @@
 #
 # This is a PowerShell Unit Test file.
-# You need a unit test framework such as Pester to run PowerShell Unit tests. 
+# You need a unit test framework such as Pester to run PowerShell Unit tests.
 # You can download Pester from http://go.microsoft.com/fwlink/?LinkID=534084
 #
 
@@ -23,16 +23,18 @@ $null = New-Item `
     -Force `
     -ErrorAction SilentlyContinue
 
-# Perform PS Script Analyzer tests on module code only
-$null = Set-PackageSource `
-    -Name PSGallery `
-    -Trusted `
-    -Force
-$null = Install-Module `
-    -Name PSScriptAnalyzer `
-    -Confirm:$False
-Import-Module `
-    -Name PSScriptAnalyzer
+if (-not (Get-Module -Name PSScriptAnalyzer -ListAvailable)) {
+    # Perform PS Script Analyzer tests on module code only
+    $null = Set-PackageSource `
+        -Name PSGallery `
+        -Trusted `
+        -Force
+    $null = Install-Module `
+        -Name PSScriptAnalyzer `
+        -Confirm:$False
+    Import-Module `
+        -Name PSScriptAnalyzer
+}
 
 Describe 'PSScriptAnalyzer' {
     Context 'PSGitHub Module, Functions and TabCompleters' {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,12 @@
-﻿#---------------------------------# 
-#      environment configuration  # 
-#---------------------------------# 
-os: WMF 5
+﻿#---------------------------------#
+#      environment configuration  #
+#---------------------------------#
 # Don't edit this build version - only manifest version number matters.
 version: 1.0.0.{build}
 environment:
   PowerShellGalleryApiKey:
     secure: 91WlCn2hlOMWHxSRh3pNANAxkB+Ji5drxv9xSKjYDD31cjShwRf0kWPvfVMBvmbV
-install: 
+install:
   - cinst -y pester
   - ps: |
       # Update AppVeyor Build Version by pulling from Manifest
@@ -34,15 +33,15 @@ install:
 
       Get-PackageProvider -Name nuget -ForceBootStrap -Force
 
-#---------------------------------# 
-#      build configuration        # 
-#---------------------------------# 
+#---------------------------------#
+#      build configuration        #
+#---------------------------------#
 
 build: false
 
-#---------------------------------# 
-#      test configuration         # 
-#---------------------------------# 
+#---------------------------------#
+#      test configuration         #
+#---------------------------------#
 
 test_script:
     - ps: |
@@ -50,16 +49,16 @@ test_script:
         $res = Invoke-Pester -OutputFormat NUnitXml -OutputFile $testResultsFile -PassThru -ExcludeTag Incomplete
         (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $testResultsFile))
         Get-ChildItem "$ENV:APPVEYOR_BUILD_FOLDER\Artifacts\*.*" | Foreach-Object { Push-AppveyorArtifact $_ }
-        if ($res.FailedCount -gt 0) { 
+        if ($res.FailedCount -gt 0) {
             throw "$($res.FailedCount) tests failed."
         }
-    
-#---------------------------------# 
-#      deployment configuration   # 
-#---------------------------------# 
 
-# scripts to run before deployment 
-deploy_script: 
+#---------------------------------#
+#      deployment configuration   #
+#---------------------------------#
+
+# scripts to run before deployment
+deploy_script:
   - ps: |
       # Creating project artifact
       $buildFolder = $ENV:APPVEYOR_BUILD_FOLDER
@@ -69,7 +68,7 @@ deploy_script:
       $null = New-Item -Path $ModuleFolder -Type directory
       $VersionFolder = Join-Path -Path $ModuleFolder -ChildPath $ENV:APPVEYOR_BUILD_VERSION
       $null = New-Item -Path $VersionFolder -Type directory
-      
+
       # Populate Version Folder
       $null = Copy-Item -Path "$buildFolder\*" -Destination $VersionFolder -Recurse -Exclude '.*','AppVeyor.yml'
 
@@ -87,11 +86,11 @@ deploy_script:
           # You can add other artifacts here
           $zipFilePath,
           $PublishScriptPath
-      ) | % { 
+      ) | % {
           Write-Host "Pushing package $_ as Appveyor artifact"
           Push-AppveyorArtifact $_
       }
-      
+
       # If this is a build of the Master branch and not a PR push
       # then publish the Module to the PowerShell Gallery.
       if ((! $ENV:APPVEYOR_PULL_REQUEST_NUMBER) `
@@ -102,7 +101,7 @@ deploy_script:
         Get-PackageProvider -Name NuGet -ForceBootstrap
         Publish-Module -Name 'PSGitHub' -RequiredVersion ${ENV:APPVEYOR_BUILD_VERSION} -NuGetApiKey $ENV:PowerShellGalleryApiKey -Confirm:$false
       }
-      
+
       # Remove Staging Folder
       $null = Remove-Item -Path $StagingFolder -Recurse -Force
 


### PR DESCRIPTION
# Bug Fixes

- Fix calling GitHub using TLS 1.2

# Improvements / Enhancements

- Added cmdlet
  - Get-GitHubLabel
  - New-GitHubLabel
  - Set-GitHubLabel
  - Remove-GitHubLabel
- Skip installing PSScriptAnalyzer if it already exist
  - Installing PSScriptAnalyzer is only allowed as administrator.
- Removed OS property from appveyor.yml
  - The build worker image WMF5 is very slow to start, and appveyor have WMF 5.1 on all the build worker images. This change uses the default build worker image

@pcgeek86 would you mind reviewing this? Let me know if you need any further and if you want me to change this in any way. Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pcgeek86/psgithub/42)
<!-- Reviewable:end -->
