### PR TITLE
Invoke GitHub api improvements

### DIFF
--- a/Functions/Private/Get-GitHubToken.ps1
+++ b/Functions/Private/Get-GitHubToken.ps1
@@ -1,38 +1,43 @@
+
 function Get-GitHubToken {
     <#
     .Synopsis
-    Internal function to retrieve the GitHub Personal Access Token from disk
+    OBSOLETE Internal function to retrieve the GitHub Personal Access Token from disk.
 
     .Notes
     Created by Trevor Sullivan <trevor@trevorsullivan.net>
     #>
-    [OutputType([System.Management.Automation.PSCredential])]
     [CmdletBinding()]
+    [OutputType([Security.SecureString])]
+    [Obsolete('Tokens should be provided through the -Token parameter or $PSDefaultParameterValues')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
     param (
     )
 
+    # Linux and macOS do not have Windows Data Protection API,
+    # so they cannot store a token encrypted in a config file
+    if ($IsMacOS -or $IsLinux) {
+        return
+    }
+
+    $tokenPath = '{0}\token.json' -f (Split-Path -Path $MyInvocation.MyCommand.Module.Path -Parent)
+
     ### Detect if we are running inside the Microsoft Azure Automation service
     if (!(Get-Command -Name Get-AutomationPSCredential -ErrorAction Ignore) -or (Get-Process -Name System)) {
-        ### Read the token from disk
-        $Token = Get-Content -Path ('{0}\token.json' -f (Split-Path -Path $MyInvocation.MyCommand.Module.Path -Parent)) -Raw | ConvertFrom-Json;
-
-        ### Combine the username and password, per GitHub developer documentation for Basic Authentication Scheme
-        ### https://developer.github.com/v3/auth/
-        $PersonalAccessToken = New-Object -TypeName PSCredential -ArgumentList @($Token.Username, ($Token.PersonalAccessToken | ConvertTo-SecureString));
-        $UserPass = '{0}:{1}' -f $PersonalAccessToken.Username, $PersonalAccessToken.GetNetworkCredential().Password;
+        # Read the token from disk
+        if (!(Test-Path $tokenPath)) {
+            return
+        }
+        $config = (Get-Content -Path $tokenPath -Raw | ConvertFrom-Json)
+        if ([string]::IsNullOrEmpty($config.PersonalAccessToken)) {
+            return
+        }
+        Write-Warning 'Relying on a token set through Set-GitHubToken is deprecated. Provide the -Token parameter or set it through $PSDefaultParameterValues'
+        $config.PersonalAccessToken | ConvertTo-SecureString
     }
     else {
         ### If we're running inside Azure Automation, then retrieve the credential from the Asset Store
-        $GitHubCredential = Get-AutomationPSCredential -Name GitHub;
-        $UserPass = '{0}:{1}' -f $GitHubCredential.UserName, $GitHubCredential.GetNetworkCredential().Password;
+        $gitHubCredential = Get-AutomationPSCredential -Name GitHub;
+        $gitHubCredential.Password
     }
-
-    ### Convert the username and password to a Base64 string (RFC 1945 / HTTP/1.0)
-    $Base64Token = [System.Convert]::ToBase64String([char[]]$UserPass) | ConvertTo-SecureString -AsPlainText -Force;
-
-    ### Return the Base64 encoded credential as a PSCredential to minimize risk of disclosure
-    ### NOTE: The username of this PSCredential instance is irrelevant, as the username / password combination
-    ####      have already been encoded as Base64 above.
-    return New-Object -TypeName PSCredential -ArgumentList @('GitHub', $Base64Token);
 }

--- a/Functions/Public/Find-GitHubRepository.ps1
+++ b/Functions/Public/Find-GitHubRepository.ps1
@@ -24,13 +24,14 @@ function Find-GitHubRepository {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
-        [string] $Keywords
-        , [Parameter(Mandatory = $false)]
+        [string] $Keywords,
+        [Parameter(Mandatory = $false)]
         [ValidateSet('Stars', 'Forks', 'Updated')]
-        [string] $SortBy
-        , [Parameter(Mandatory = $false)]
+        [string] $SortBy,
+        [Parameter(Mandatory = $false)]
         [ValidateSet('Ascending', 'Descending')]
-        [string] $SortOrder
+        [string] $SortOrder,
+        [Security.SecureString] $Token = (Get-GitHubToken)
     )
 
     ### Create a stub HTTP message body
@@ -64,9 +65,10 @@ function Find-GitHubRepository {
 
     ### Build the parameters for the REST API call
     $ApiCall = @{
-        Body       = $ApiBody | ConvertTo-Json;
-        RestMethod = 'search/repositories';
-        Method     = 'Get';
+        Body   = $ApiBody | ConvertTo-Json;
+        Uri    = 'search/repositories';
+        Method = 'Get';
+        Token  = $Token
     }
 
     ### Invoke the GitHub REST API

--- a/Functions/Public/Get-GitHubAuthenticatedUser.ps1
+++ b/Functions/Public/Get-GitHubAuthenticatedUser.ps1
@@ -2,9 +2,10 @@ function Get-GitHubAuthenticatedUser {
     [OutputType([System.Object])]
     [CmdletBinding()]
     param (
+        [Security.SecureString] $Token = (Get-GitHubToken)
     )
 
-    $RestMethod = 'user'
-    $Result = Invoke-GitHubApi -RestMethod $RestMethod -Method Default
+    $Uri = 'user'
+    $Result = Invoke-GitHubApi -Uri $Uri -Method Default
     $Result
 }

--- a/Functions/Public/Get-GitHubComment.ps1
+++ b/Functions/Public/Get-GitHubComment.ps1
@@ -64,41 +64,42 @@ function Get-GitHubComment {
     param (
         [Parameter(Mandatory = $true)]
         [Alias('User')]
-        [string] $Owner
-        , [Parameter(Mandatory = $true)]
-        [string] $Repository
-        , [Parameter(Mandatory = $true, ParameterSetName = 'InRepo')]
-        [switch] $All
-        , [Parameter(Mandatory = $true, ParameterSetName = 'InIssue')]
+        [string] $Owner,
+        [Parameter(Mandatory = $true)]
+        [string] $Repository,
+        [Parameter(Mandatory = $true, ParameterSetName = 'InRepo')]
+        [switch] $All,
+        [Parameter(Mandatory = $true, ParameterSetName = 'InIssue')]
         [ValidateRange(1, [int]::MaxValue)]
-        [int] $Number
-        , [Parameter(Mandatory = $true, ParameterSetName = 'Single')]
+        [int] $Number,
+        [Parameter(Mandatory = $true, ParameterSetName = 'Single')]
         [ValidateRange(1, [int]::MaxValue)]
-        [int] $CommentId
-        , [Parameter(Mandatory = $false, ParameterSetName = 'InRepo')]
+        [int] $CommentId,
+        [Parameter(Mandatory = $false, ParameterSetName = 'InRepo')]
         [Parameter(Mandatory = $false, ParameterSetName = 'InIssue')]
         [ValidateRange(1, [int]::MaxValue)]
-        [int] $Page
-        , [Parameter(Mandatory = $false, ParameterSetName = 'InRepo')]
+        [int] $Page,
+        [Parameter(Mandatory = $false, ParameterSetName = 'InRepo')]
         [ValidateSet('created', 'updated')]
-        [string] $Sort
-        , [Parameter(Mandatory = $false, ParameterSetName = 'InRepo')]
+        [string] $Sort,
+        [Parameter(Mandatory = $false, ParameterSetName = 'InRepo')]
         [ValidateSet('asc', 'desc')]
-        [string] $Direction
-        , [Parameter(Mandatory = $false, ParameterSetName = 'InRepo')]
+        [string] $Direction,
+        [Parameter(Mandatory = $false, ParameterSetName = 'InRepo')]
         [Parameter(Mandatory = $false, ParameterSetName = 'InIssue')]
-        [string] $Since
+        [string] $Since,
+        [Security.SecureString] $Token = (Get-GitHubToken)
     )
 
-    $restMethod = 'repos/{0}/{1}/issues' -f $Owner, $Repository
+    $uri = 'repos/{0}/{1}/issues' -f $Owner, $Repository
     if ($All) {
-        $restMethod += '/comments'
+        $uri += '/comments'
     }
     elseif ($Number) {
-        $restMethod += '/{0}/comments' -f $Number
+        $uri += '/{0}/comments' -f $Number
     }
     elseif ($CommentId) {
-        $restMethod += '/comments/{0}' -f $CommentId
+        $uri += '/comments/{0}' -f $CommentId
     }
 
     $queryParameters = @()
@@ -119,12 +120,13 @@ function Get-GitHubComment {
     }
 
     if ($queryParameters) {
-        $restMethod += "?" + ($queryParameters -join '&')
+        $uri += "?" + ($queryParameters -join '&')
     }
 
     $apiCall = @{
-        Method     = 'Get';
-        RestMethod = $restMethod
+        Method = 'Get';
+        Uri    = $uri
+        Token  = $Token
     }
 
     Invoke-GitHubApi @apiCall

--- a/Functions/Public/Get-GitHubGist.ps1
+++ b/Functions/Public/Get-GitHubGist.ps1
@@ -65,20 +65,22 @@ function Get-GitHubGist {
         [String]$Id,
         [Parameter(ParameterSetName = 'Target')]
         [ValidateSet('Public', 'Starred')]
-        [String]$Target
+        [String]$Target,
+        [Security.SecureString] $Token = (Get-GitHubToken)
     )
 
     switch ($PSCmdlet.ParameterSetName) {
-        'Owner' { $restMethod = 'users/{0}/gists' -f $Owner; break; }
-        'Id' { $restMethod = 'gists/{0}' -f $Id; break; }
-        'Target' { if ($Target -eq 'Public') { $restMethod = 'gists/public'} else { $restMethod = 'gists/starred' }; break; }
-        default { $restMethod = 'gists'; break; }
+        'Owner' { $uri = 'users/{0}/gists' -f $Owner; break; }
+        'Id' { $uri = 'gists/{0}' -f $Id; break; }
+        'Target' { if ($Target -eq 'Public') { $uri = 'gists/public'} else { $uri = 'gists/starred' }; break; }
+        default { $uri = 'gists'; break; }
     }
 
     $apiCall = @{
         #Body = ''
-        RestMethod = $restMethod
-        Method     = 'Get'
+        Uri    = $uri
+        Method = 'Get'
+        Token  = $Token
     }
 
     $ResultList = Invoke-GitHubApi @apiCall

--- a/Functions/Public/Get-GitHubIssue.ps1
+++ b/Functions/Public/Get-GitHubIssue.ps1
@@ -95,54 +95,55 @@ function Get-GitHubIssue {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true, ParameterSetName = 'All')]
-        [switch] $All
-        , [Parameter(Mandatory = $true, ParameterSetName = 'ForUser')]
-        [switch] $ForUser
-        , [Parameter(Mandatory = $true, ParameterSetName = 'Organization')]
-        [string] $Organization
-        , [Parameter(Mandatory = $true, ParameterSetName = 'Repository')]
+        [switch] $All,
+        [Parameter(Mandatory = $true, ParameterSetName = 'ForUser')]
+        [switch] $ForUser,
+        [Parameter(Mandatory = $true, ParameterSetName = 'Organization')]
+        [string] $Organization,
+        [Parameter(Mandatory = $true, ParameterSetName = 'Repository')]
         [Alias('User')]
-        [string] $Owner
-        , [Parameter(Mandatory = $true, ParameterSetName = 'Repository')]
-        [string] $Repository
-        , [Parameter(Mandatory = $false, ParameterSetName = 'Repository')]
+        [string] $Owner,
+        [Parameter(Mandatory = $true, ParameterSetName = 'Repository')]
+        [string] $Repository,
+        [Parameter(Mandatory = $false, ParameterSetName = 'Repository')]
         [ValidateRange(1, [int]::MaxValue)]
-        [int] $Number
-        , [Parameter()]
+        [int] $Number,
+        [Parameter()]
         [ValidateRange(1, [int]::MaxValue)]
-        [int] $Page
-        , [Parameter()]
+        [int] $Page,
+        [Parameter()]
         [ValidateSet('assigned', 'created', 'mentioned', 'subscribed', 'all')]
-        [string] $Filter
-        , [Parameter()]
+        [string] $Filter,
+        [Parameter()]
         [ValidateSet('open', 'closed', 'all')]
-        [string] $State
-        , [Parameter()]
-        [string[]] $Labels
-        , [Parameter()]
+        [string] $State,
+        [Parameter()]
+        [string[]] $Labels,
+        [Parameter()]
         [ValidateSet('created', 'updated', 'comments')]
-        [string] $Sort
-        , [Parameter()]
+        [string] $Sort,
+        [Parameter()]
         [ValidateSet('asc', 'desc')]
-        [string] $Direction
-        , [Parameter()]
-        [string] $Since
+        [string] $Direction,
+        [Parameter()]
+        [string] $Since,
+        [Security.SecureString] $Token = (Get-GitHubToken)
     )
 
     if ($Repository) {
-        $restMethod = 'repos/{0}/{1}/issues' -f $Owner, $Repository
+        $uri = 'repos/{0}/{1}/issues' -f $Owner, $Repository
         if ($Number -gt 0) {
-            $restMethod += ("/{0}" -f $Number)
+            $uri += ("/{0}" -f $Number)
         }
     }
     elseif ($Organization) {
-        $restMethod = 'orgs/{0}/issues' -f $Organization
+        $uri = 'orgs/{0}/issues' -f $Organization
     }
     elseif ($ForUser) {
-        $restMethod = 'user/issues'
+        $uri = 'user/issues'
     }
     else {
-        $restMethod = 'issues'
+        $uri = 'issues'
     }
 
     $queryParameters = @()
@@ -175,12 +176,13 @@ function Get-GitHubIssue {
     }
 
     if ($queryParameters) {
-        $restMethod += "?" + ($queryParameters -join '&')
+        $uri += "?" + ($queryParameters -join '&')
     }
 
     $apiCall = @{
-        Method     = 'Get';
-        RestMethod = $restMethod
+        Method = 'Get';
+        Uri    = $uri
+        Token  = $Token
     }
 
     Invoke-GitHubApi @apiCall

--- a/Functions/Public/Get-GitHubLabel.ps1
+++ b/Functions/Public/Get-GitHubLabel.ps1
@@ -40,20 +40,21 @@ function Get-GitHubLabel {
     param (
         [Parameter(Mandatory = $true, ParameterSetName = 'Repository')]
         [Alias('User')]
-        [string] $Owner
-        , [Parameter(Mandatory = $true, ParameterSetName = 'Repository')]
-        [string] $Repository
-        , [Parameter(Mandatory = $false, ParameterSetName = 'Repository')]
-        [string] $Name
-        , [Parameter()]
+        [string] $Owner,
+        [Parameter(Mandatory = $true, ParameterSetName = 'Repository')]
+        [string] $Repository,
+        [Parameter(Mandatory = $false, ParameterSetName = 'Repository')]
+        [string] $Name,
+        [Parameter()]
         [ValidateRange(1, [int]::MaxValue)]
-        [int] $Page
+        [int] $Page,
+        [Security.SecureString] $Token = (Get-GitHubToken)
     )
 
-    $restMethod = 'repos/{0}/{1}/labels' -f $Owner, $Repository
+    $uri = 'repos/{0}/{1}/labels' -f $Owner, $Repository
 
     if ($Name) {
-        $restMethod += ("/{0}" -f $Name)
+        $uri += ("/{0}" -f $Name)
     }
 
     $queryParameters = @()
@@ -62,15 +63,16 @@ function Get-GitHubLabel {
     }
 
     if ($queryParameters) {
-        $restMethod += "?" + ($queryParameters -join '&')
+        $uri += "?" + ($queryParameters -join '&')
     }
 
     $apiCall = @{
-        Headers    = @{
+        Headers = @{
             Accept = 'application/vnd.github.symmetra-preview+json'
         }
-        Method     = 'Get'
-        RestMethod = $restMethod
+        Method  = 'Get'
+        Uri     = $uri
+        Token   = $Token
     }
 
     Invoke-GitHubApi @apiCall

--- a/Functions/Public/Get-GitHubLicense.ps1
+++ b/Functions/Public/Get-GitHubLicense.ps1
@@ -20,26 +20,22 @@ function Get-GitHubLicense {
 
     #>
     [CmdletBinding()]
-    param
-    (
+    param(
         [Parameter(Mandatory = $false, Position = 0)]
-        [string] $LicenseId
+        [string] $LicenseId,
+        [Security.SecureString] $Token = (Get-GitHubToken)
     )
 
-    begin {
-
+    if (-Not ($LicenseId)) {
+        $uri = 'licenses'
+    }
+    else {
+        $uri = 'licenses/{0}' -f $LicenseId
     }
 
-    process {
-        if (-Not ($LicenseId)) {
-            $restMethod = 'licenses'
-        }
-        else {
-            $restMethod = 'licenses/{0}' -f $LicenseId
-        }
+    $headers = @{
+        Accept = 'application/vnd.github.drax-preview+json'
+        Token  = $Token
     }
-
-    end {
-        Invoke-GitHubApi -Method get -RestMethod $restMethod -Preview
-    }
+    Invoke-GitHubApi -Method get -Uri $uri -Headers $headers
 }

--- a/Functions/Public/Get-GitHubMilestone.ps1
+++ b/Functions/Public/Get-GitHubMilestone.ps1
@@ -29,20 +29,21 @@ function Get-GitHubMilestone {
     param (
         [Parameter(Mandatory = $true)]
         [Alias('User')]
-        [string] $Owner
-        , [Parameter(Mandatory = $true)]
-        [string] $Repository
-        , [Parameter(ParameterSetName = 'SpecificMilestone', Mandatory = $true)]
-        [string] $Milestone
-        , [Parameter(ParameterSetName = 'FindMilestones', Mandatory = $false)]
+        [string] $Owner,
+        [Parameter(Mandatory = $true)]
+        [string] $Repository,
+        [Parameter(ParameterSetName = 'SpecificMilestone', Mandatory = $true)]
+        [string] $Milestone,
+        [Parameter(ParameterSetName = 'FindMilestones', Mandatory = $false)]
         [ValidateSet('Open', 'Closed', 'All')]
-        [string] $State
-        , [Parameter(ParameterSetName = 'FindMilestones', Mandatory = $false)]
+        [string] $State,
+        [Parameter(ParameterSetName = 'FindMilestones', Mandatory = $false)]
         [ValidateSet('DueDate', 'Completeness')]
-        [string] $Sort
-        , [Parameter(ParameterSetName = 'FindMilestones', Mandatory = $false)]
+        [string] $Sort,
+        [Parameter(ParameterSetName = 'FindMilestones', Mandatory = $false)]
         [ValidateSet('Ascending', 'Descending')]
-        [string] $Direction
+        [string] $Direction,
+        [Security.SecureString] $Token = (Get-GitHubToken)
     )
 
     ### Build the core message body -- we'll add more properties soon
@@ -66,16 +67,16 @@ function Get-GitHubMilestone {
     if ($State) {
         switch ($State) {
             'Open' {
-                $State = 'open'; break; 
+                $State = 'open'; break;
             }
             'Closed' {
-                $State = 'closed'; break; 
+                $State = 'closed'; break;
             }
             'All' {
-                $State = 'all'; break; 
+                $State = 'all'; break;
             }
             default {
-                break; 
+                break;
             }
         }
         $ApiBody.Add('state', $State);
@@ -85,13 +86,13 @@ function Get-GitHubMilestone {
     if ($Direction) {
         switch ($Direction) {
             'Ascending' {
-                $Direction = 'asc'; break; 
+                $Direction = 'asc'; break;
             }
             'Descending' {
-                $Direction = 'desc'; break; 
+                $Direction = 'desc'; break;
             }
             default {
-                break; 
+                break;
             }
         }
         $ApiBody.Add('direction', $Direction);
@@ -99,17 +100,18 @@ function Get-GitHubMilestone {
 
     ### Determine the appropriate REST method to use
     if ($Milestone) {
-        $RestMethod = '/repos/{0}/{1}/milestones/{2}' -f $Owner, $Repository, $Milestone; 
+        $Uri = '/repos/{0}/{1}/milestones/{2}' -f $Owner, $Repository, $Milestone;
     }
     else {
-        $RestMethod = '/repos/{0}/{1}/milestones' -f $Owner, $Repository; 
+        $Uri = '/repos/{0}/{1}/milestones' -f $Owner, $Repository;
     }
 
     ### Set up the API call
     $ApiCall = @{
-        Body       = $ApiBody | ConvertTo-Json
-        RestMethod = $RestMethod;
-        Method     = 'Get';
+        Body   = $ApiBody | ConvertTo-Json
+        Uri    = $Uri;
+        Method = 'Get';
+        Token  = $Token
     }
 
     ### Invoke the GitHub REST method

--- a/Functions/Public/Get-GitHubRelease.ps1
+++ b/Functions/Public/Get-GitHubRelease.ps1
@@ -55,7 +55,8 @@ function Get-GitHubRelease {
         [Parameter(Mandatory = $false, ParameterSetName = 'TagName')]
         [String] $TagName,
         [Parameter(Mandatory = $false, ParameterSetName = 'Latest')]
-        [Switch] $Latest
+        [Switch] $Latest,
+        [Security.SecureString] $Token = (Get-GitHubToken)
     )
 
     begin {
@@ -64,16 +65,17 @@ function Get-GitHubRelease {
     process {
         # set the rest method
         switch ($PSCmdlet.ParameterSetName) {
-            'Id' { $restMethod = "repos/$Owner/$Repository/releases/$Id"; break; }
-            'TagName' { $restMethod = "repos/$Owner/$Repository/releases/tags/$TagName"; break; }
-            'Latest' { $restMethod = "repos/$Owner/$Repository/releases/latest"; break; }
-            Default { $restMethod = "repos/$Owner/$Repository/releases"; break; }
+            'Id' { $uri = "repos/$Owner/$Repository/releases/$Id"; break; }
+            'TagName' { $uri = "repos/$Owner/$Repository/releases/tags/$TagName"; break; }
+            'Latest' { $uri = "repos/$Owner/$Repository/releases/latest"; break; }
+            Default { $uri = "repos/$Owner/$Repository/releases"; break; }
         }
 
         # set the API call parameter
         $apiCall = @{
-            RestMethod = $restMethod
-            Method     = 'Get'
+            Uri    = $uri
+            Method = 'Get'
+            Token  = $Token
         }
     }
 

--- a/Functions/Public/Get-GitHubReleaseAsset.ps1
+++ b/Functions/Public/Get-GitHubReleaseAsset.ps1
@@ -42,7 +42,8 @@ function Get-GitHubReleaseAsset {
         [Parameter(Mandatory = $true, ParameterSetName = 'ReleaseId')]
         [String] $ReleaseId,
         [Parameter(Mandatory = $false, ParameterSetName = 'Id')]
-        [String] $Id
+        [String] $Id,
+        [Security.SecureString] $Token = (Get-GitHubToken)
     )
 
     begin {
@@ -51,15 +52,16 @@ function Get-GitHubReleaseAsset {
     process {
         # set the rest method
         switch ($PSCmdlet.ParameterSetName) {
-            'ReleaseId' { $restMethod = "repos/$Owner/$Repository/releases/$ReleaseId/assets"; break; }
-            'Id' { $restMethod = "repos/$Owner/$Repository/releases/assets/$Id"; break; }
-            Default { $restMethod = "repos/$Owner/$Repository/releases/$ReleaseId/assets"; break; }
+            'ReleaseId' { $uri = "repos/$Owner/$Repository/releases/$ReleaseId/assets"; break; }
+            'Id' { $uri = "repos/$Owner/$Repository/releases/assets/$Id"; break; }
+            Default { $uri = "repos/$Owner/$Repository/releases/$ReleaseId/assets"; break; }
         }
 
         # set the API call parameter
         $apiCall = @{
-            RestMethod = $restMethod
-            Method     = 'Get'
+            Uri    = $uri
+            Method = 'Get'
+            Token  = $Token
         }
     }
 

--- a/Functions/Public/Get-GitHubRepository.ps1
+++ b/Functions/Public/Get-GitHubRepository.ps1
@@ -57,35 +57,37 @@ function Get-GitHubRepository {
         [Parameter(Mandatory, ParameterSetName = 'SpecificOwnerAndRepositoryLicense')]
         [switch] $License,
         [Parameter(Mandatory, ParameterSetName = 'SpecificOwnerAndRepositoryReadMe')]
-        [switch] $ReadMe
+        [switch] $ReadMe,
+        [Security.SecureString] $Token = (Get-GitHubToken)
     )
 
     begin {
         switch -Wildcard ($PSCmdlet.ParameterSetName) {
             'AllForOwner' {
                 if ($Owner -eq $(Get-GitHubAuthenticatedUser).login) {
-                    $RestMethod = 'user/repos'
+                    $Uri = 'user/repos'
                 }
                 else {
-                    $RestMethod = 'users/{0}/repos' -f $Owner
+                    $Uri = 'users/{0}/repos' -f $Owner
                 }
             }
             'SpecificOwnerAndRepository*' {
-                $RestMethod = 'repos/{0}/{1}' -f $Owner, $Repository
+                $Uri = 'repos/{0}/{1}' -f $Owner, $Repository
             }
             'SpecificOwnerAndRepositoryReadMe' {
-                $RestMethod += '/readme'
+                $Uri += '/readme'
             }
             'SpecificOwnerAndRepositoryLicense' {
-                $RestMethod += '/license'
+                $Uri += '/license'
             }
         }
     }
 
     process {
         $ApiCall = @{
-            RestMethod = $RestMethod
-            Method     = 'Get'
+            Uri    = $Uri
+            Method = 'Get'
+            Token  = $Token
         }
     }
 

--- a/Functions/Public/New-GitHubComment.ps1
+++ b/Functions/Public/New-GitHubComment.ps1
@@ -32,26 +32,28 @@ function New-GitHubComment {
     param (
         [Parameter(Mandatory = $true)]
         [Alias('User')]
-        [string] $Owner
-        , [Parameter(Mandatory = $true)]
-        [string] $Repository
-        , [Parameter(Mandatory = $true)]
+        [string] $Owner,
+        [Parameter(Mandatory = $true)]
+        [string] $Repository,
+        [Parameter(Mandatory = $true)]
         [ValidateRange(1, [int]::MaxValue)]
-        [int] $Number
-        , [Parameter(Mandatory = $true)]
-        [string] $Body
+        [int] $Number,
+        [Parameter(Mandatory = $true)]
+        [string] $Body,
+        [Security.SecureString] $Token = (Get-GitHubToken)
     )
 
-    $restMethod = 'repos/{0}/{1}/issues/{2}/comments' -f $Owner, $Repository, $Number
+    $uri = 'repos/{0}/{1}/issues/{2}/comments' -f $Owner, $Repository, $Number
 
     $apiBody = @{
         body = $Body
     } | ConvertTo-Json
 
     $apiCall = @{
-        Method     = 'Post';
-        RestMethod = $restMethod;
-        Body       = $apiBody;
+        Method = 'Post';
+        Uri    = $uri;
+        Body   = $apiBody;
+        Token  = $Token
     }
 
     Invoke-GitHubApi @apiCall

--- a/Functions/Public/New-GitHubFork.ps1
+++ b/Functions/Public/New-GitHubFork.ps1
@@ -50,9 +50,10 @@ function New-GitHubFork {
 
         # construct the api call
         $apiCall = @{
-            Body       = $Body
-            Method     = 'post'
-            RestMethod = "repos/$Owner/$Repository/forks"
+            Body   = $Body
+            Method = 'post'
+            Uri    = "repos/$Owner/$Repository/forks"
+            Token  = $Token
         }
     }
 

--- a/Functions/Public/New-GitHubGist.ps1
+++ b/Functions/Public/New-GitHubGist.ps1
@@ -69,7 +69,8 @@ function New-GitHubGist {
         [Parameter(HelpMessage = 'Description of the Gist.')]
         [String]$Description,
         [Parameter(HelpMessage = 'Allows the Gist to be viewed by others.')]
-        [Switch] $Public
+        [Switch] $Public,
+        [Security.SecureString] $Token = (Get-GitHubToken)
     )
 
     DynamicParam {
@@ -131,9 +132,10 @@ function New-GitHubGist {
 
         # Splat API call Parameters.
         $apiCall = @{
-            Body       = ConvertTo-Json -InputObject $body
-            RestMethod = 'gists'
-            Method     = 'Post'
+            Body   = ConvertTo-Json -InputObject $body
+            Uri    = 'gists'
+            Method = 'Post'
+            Token  = $Token
         }
 
         # Create the Gist.

--- a/Functions/Public/New-GitHubIssue.ps1
+++ b/Functions/Public/New-GitHubIssue.ps1
@@ -34,19 +34,20 @@ function New-GitHubIssue {
     param (
         [Parameter(Mandatory = $true)]
         [Alias('User')]
-        [string] $Owner
-        , [Parameter(Mandatory = $true)]
-        [string] $Repository
-        , [Parameter(Mandatory = $true)]
-        [string] $Title
-        , [Parameter(Mandatory = $false)]
-        [string] $Body
-        , [Parameter(Mandatory = $false)]
-        [string] $Assignee
-        , [Parameter(Mandatory = $false)]
-        [string[]] $Labels
-        , [Parameter(Mandatory = $false)]
-        [string] $Milestone
+        [string] $Owner,
+        [Parameter(Mandatory = $true)]
+        [string] $Repository,
+        [Parameter(Mandatory = $true)]
+        [string] $Title,
+        [Parameter(Mandatory = $false)]
+        [string] $Body,
+        [Parameter(Mandatory = $false)]
+        [string] $Assignee,
+        [Parameter(Mandatory = $false)]
+        [string[]] $Labels,
+        [Parameter(Mandatory = $false)]
+        [string] $Milestone,
+        [Security.SecureString] $Token = (Get-GitHubToken)
     )
 
     ### Build the core message body -- we'll add more properties soon
@@ -69,9 +70,10 @@ function New-GitHubIssue {
 
     ### Set up the API call
     $ApiCall = @{
-        Body       = $ApiBody | ConvertTo-Json
-        RestMethod = 'repos/{0}/{1}/issues' -f $Owner, $Repository;
-        Method     = 'Post';
+        Body   = $ApiBody | ConvertTo-Json
+        Uri    = 'repos/{0}/{1}/issues' -f $Owner, $Repository;
+        Method = 'Post';
+        Token  = $Token
     }
 
     ### Invoke the GitHub REST method

--- a/Functions/Public/New-GitHubLabel.ps1
+++ b/Functions/Public/New-GitHubLabel.ps1
@@ -48,17 +48,18 @@ function New-GitHubLabel {
     param (
         [Parameter(Mandatory = $true, ParameterSetName = 'Repository')]
         [Alias('User')]
-        [string] $Owner
-        , [Parameter(Mandatory = $true, ParameterSetName = 'Repository')]
-        [string] $Repository
-        , [Parameter(Mandatory = $true, ParameterSetName = 'Repository')]
-        [string] $Name
-        , [Parameter(Mandatory = $true, ParameterSetName = 'Repository')]
-        [string] $Color
-        , [Parameter(Mandatory = $false, ParameterSetName = 'Repository')]
-        [string] $Description
-        , [Parameter()]
-        [switch] $Force
+        [string] $Owner,
+        [Parameter(Mandatory = $true, ParameterSetName = 'Repository')]
+        [string] $Repository,
+        [Parameter(Mandatory = $true, ParameterSetName = 'Repository')]
+        [string] $Name,
+        [Parameter(Mandatory = $true, ParameterSetName = 'Repository')]
+        [string] $Color,
+        [Parameter(Mandatory = $false, ParameterSetName = 'Repository')]
+        [string] $Description,
+        [Parameter()]
+        [switch] $Force,
+        [Security.SecureString] $Token = (Get-GitHubToken)
     )
 
     $shouldProcessCaption = 'Creating new GitHub label'
@@ -66,7 +67,7 @@ function New-GitHubLabel {
     $shouldProcessWarning = 'Do you want to create the GitHub label ''{0}'' in the repository ''{1}/{2}''?' -f $Name, $Owner, $Repository
 
     if ($Force -or $PSCmdlet.ShouldProcess($shouldProcessDescription, $shouldProcessWarning, $shouldProcessCaption)) {
-        $restMethod = 'repos/{0}/{1}/labels' -f $Owner, $Repository
+        $uri = 'repos/{0}/{1}/labels' -f $Owner, $Repository
 
         $bodyProperties = @{
             name  = $Name
@@ -78,12 +79,13 @@ function New-GitHubLabel {
         }
 
         $apiCall = @{
-            Headers    = @{
+            Headers = @{
                 Accept = 'application/vnd.github.symmetra-preview+json'
             }
-            Method     = 'Post'
-            RestMethod = $restMethod
-            Body       = $bodyProperties | ConvertTo-Json
+            Method  = 'Post'
+            Uri     = $uri
+            Body    = $bodyProperties | ConvertTo-Json
+            Token   = $Token
         }
 
         # Variable scope ensures that parent session remains unchanged

--- a/Functions/Public/New-GitHubPullRequest.ps1
+++ b/Functions/Public/New-GitHubPullRequest.ps1
@@ -66,7 +66,8 @@ function New-GitHubPullRequest {
         [Parameter(Mandatory = $false, ParameterSetName = 'title')]
         [string] $Body,
         [Parameter(Mandatory = $true, ParameterSetName = 'issue')]
-        [int] $issue
+        [int] $issue,
+        [Security.SecureString] $Token = (Get-GitHubToken)
     )
 
     begin {
@@ -98,9 +99,10 @@ function New-GitHubPullRequest {
 
         # construct the parameters of the ApiCall
         $ApiCall = @{
-            Body       = $ApiBody
-            Method     = 'post'
-            RestMethod = "repos/$Owner/$Repository/pulls"
+            Body   = $ApiBody
+            Method = 'post'
+            Uri    = "repos/$Owner/$Repository/pulls"
+            Token  = $Token
         }
 
     }

--- a/Functions/Public/New-GitHubRelease.ps1
+++ b/Functions/Public/New-GitHubRelease.ps1
@@ -63,7 +63,8 @@ function New-GitHubRelease {
         [Parameter()]
         [switch] $Draft,
         [Parameter()]
-        [switch] $PreRelease
+        [switch] $PreRelease,
+        [Security.SecureString] $Token = (Get-GitHubToken)
     )
 
     begin {
@@ -109,9 +110,10 @@ function New-GitHubRelease {
         ### create a API call
         $apiCall =
         @{
-            Body       = $RequestBody | ConvertTo-Json
-            Method     = 'post'
-            RestMethod = "repos/$Owner/$Repository/releases"
+            Body   = $RequestBody | ConvertTo-Json
+            Method = 'post'
+            Uri    = "repos/$Owner/$Repository/releases"
+            Token  = $Token
         }
     }
 

--- a/Functions/Public/New-GitHubReleaseAsset.ps1
+++ b/Functions/Public/New-GitHubReleaseAsset.ps1
@@ -43,7 +43,8 @@ function New-GitHubReleaseAsset {
         [Parameter(Mandatory = $true)]
         [string] $Path,
         [Parameter(Mandatory = $false)]
-        [string] $ContentType = 'application/zip'
+        [string] $ContentType = 'application/zip',
+        [Security.SecureString] $Token = (Get-GitHubToken)
     )
 
     begin {
@@ -62,10 +63,11 @@ function New-GitHubReleaseAsset {
         ### create a API call
         $apiCall =
         @{
-            Body       = Get-Content -Path $Path -Raw
-            Headers    = @{'Content-Type' = $ContentType}
-            Method     = 'post'
-            RestMethod = "https://uploads.github.com/repos/$Owner/$Repository/releases/$ReleaseId/assets?name=$Name&label=$Name"
+            Body    = Get-Content -Path $Path -Raw
+            Headers = @{'Content-Type' = $ContentType}
+            Method  = 'post'
+            Uri     = "https://uploads.github.com/repos/$Owner/$Repository/releases/$ReleaseId/assets?name=$Name&label=$Name"
+            Token   = $Token
         }
     }
 

--- a/Functions/Public/New-GitHubRepository.ps1
+++ b/Functions/Public/New-GitHubRepository.ps1
@@ -27,17 +27,18 @@ function New-GitHubRepository {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
-        [string] $Name
-        , [Parameter(Mandatory = $false)]
-        [string] $Description
-        , [Parameter(Mandatory = $false)]
-        [string] $Homepage
-        , [Parameter(Mandatory = $false)]
-        [switch] $IncludeReadme
-        , [Parameter(Mandatory = $false)]
-        [string] $DisableIssues
-        , [Parameter(Mandatory = $false)]
-        [string] $Private
+        [string] $Name,
+        [Parameter(Mandatory = $false)]
+        [string] $Description,
+        [Parameter(Mandatory = $false)]
+        [string] $Homepage,
+        [Parameter(Mandatory = $false)]
+        [switch] $IncludeReadme,
+        [Parameter(Mandatory = $false)]
+        [string] $DisableIssues,
+        [Parameter(Mandatory = $false)]
+        [string] $Private,
+        [Security.SecureString] $Token = (Get-GitHubToken)
     )
 
     $Body = @{
@@ -50,6 +51,6 @@ function New-GitHubRepository {
     } | ConvertTo-Json;
     Write-Verbose -Message $Body;
 
-    Invoke-GitHubApi -RestMethod user/repos -Body $Body -Method Post;
+    Invoke-GitHubApi -Uri user/repos -Body $Body -Method Post -Token $Token;
 
 }

--- a/Functions/Public/Remove-GitHubGist.ps1
+++ b/Functions/Public/Remove-GitHubGist.ps1
@@ -31,12 +31,12 @@ function Remove-GitHubGist {
 
     [CmdletBinding(ConfirmImpact = 'High', SupportsShouldProcess = $true)]
     [OutputType([Void])]
-
     Param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [String[]] $Id,
         [Parameter()]
-        [String[]]$FileName
+        [String[]]$FileName,
+        [Security.SecureString] $Token = (Get-GitHubToken)
     )
 
     Process {
@@ -49,17 +49,18 @@ function Remove-GitHubGist {
                     foreach ($file in $FileName) {
                         $body.files.Add($file, $null)
                     }
-                    $restMethod = 'PATCH'
+                    $uri = 'PATCH'
                 }
                 else {
                     $body = $null
-                    $restMethod = 'DELETE'
+                    $uri = 'DELETE'
                 }
 
                 $ApiCall = @{
-                    Body       = ConvertTo-Json -InputObject $body
-                    RestMethod = 'gists/{0}' -f $item
-                    Method     = $restMethod
+                    Body   = ConvertTo-Json -InputObject $body
+                    Uri    = 'gists/{0}' -f $item
+                    Method = $uri
+                    Token  = $Token
                 }
 
                 Invoke-GitHubApi @ApiCall

--- a/Functions/Public/Remove-GitHubLabel.ps1
+++ b/Functions/Public/Remove-GitHubLabel.ps1
@@ -31,13 +31,14 @@ function Remove-GitHubLabel {
     param (
         [Parameter(Mandatory = $true, ParameterSetName = 'Repository')]
         [Alias('User')]
-        [string] $Owner
-        , [Parameter(Mandatory = $true, ParameterSetName = 'Repository')]
-        [string] $Repository
-        , [Parameter(Mandatory = $true, ParameterSetName = 'Repository')]
-        [string] $Name
-        , [Parameter()]
-        [switch] $Force
+        [string] $Owner,
+        [Parameter(Mandatory = $true, ParameterSetName = 'Repository')]
+        [string] $Repository,
+        [Parameter(Mandatory = $true, ParameterSetName = 'Repository')]
+        [string] $Name,
+        [Parameter()]
+        [switch] $Force,
+        [Security.SecureString] $Token = (Get-GitHubToken)
     )
 
     $shouldProcessCaption = 'Remove an existing GitHub label'
@@ -45,14 +46,15 @@ function Remove-GitHubLabel {
     $shouldProcessWarning = 'Do you want to remove the GitHub label ''{0}'' in the repository ''{1}/{2}''?' -f $Name, $Owner, $Repository
 
     if ($Force -or $PSCmdlet.ShouldProcess($shouldProcessDescription, $shouldProcessWarning, $shouldProcessCaption)) {
-        $restMethod = 'repos/{0}/{1}/labels/{2}' -f $Owner, $Repository, $Name
+        $uri = 'repos/{0}/{1}/labels/{2}' -f $Owner, $Repository, $Name
 
         $apiCall = @{
-            Headers    = @{
+            Headers = @{
                 Accept = 'application/vnd.github.symmetra-preview+json'
             }
-            Method     = 'Delete'
-            RestMethod = $restMethod
+            Method  = 'Delete'
+            Uri     = $uri
+            Token   = $Token
         }
 
         # Variable scope ensures that parent session remains unchanged

--- a/Functions/Public/Remove-GitHubReleaseAsset.ps1
+++ b/Functions/Public/Remove-GitHubReleaseAsset.ps1
@@ -29,13 +29,15 @@ function Remove-GitHubReleaseAsset {
         [Parameter(Mandatory = $true)]
         [string] $RepositoryName,
         [Parameter(Mandatory = $true)]
-        [String] $Id
+        [String] $Id,
+        [Security.SecureString] $Token = (Get-GitHubToken)
     )
 
     Process {
         $ApiCall = @{
-            RestMethod = "repos/$Owner/$RepositoryName/releases/assets/$Id"
-            Method     = 'delete'
+            Uri    = "repos/$Owner/$RepositoryName/releases/assets/$Id"
+            Method = 'delete'
+            Token  = $Token
         }
     }
 

--- a/Functions/Public/Remove-GitHubRepository.ps1
+++ b/Functions/Public/Remove-GitHubRepository.ps1
@@ -9,11 +9,12 @@ function Remove-GitHubRepository {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
-        [string] $Owner
-        , [Parameter(Mandatory = $true)]
-        [string] $Name
+        [string] $Owner,
+        [Parameter(Mandatory = $true)]
+        [string] $Name,
+        [Security.SecureString] $Token = (Get-GitHubToken)
     )
 
     $Method = 'repos/{0}/{1}' -f $Owner, $Name;
-    Invoke-GitHubApi -RestMethod $Method -Method Delete;
+    Invoke-GitHubApi -Uri $Method -Method Delete -Token $Token;
 }

--- a/Functions/Public/Set-GitHubAuthenticatedUser.ps1
+++ b/Functions/Public/Set-GitHubAuthenticatedUser.ps1
@@ -18,22 +18,22 @@ function Set-GitHubAuthenticatedUser {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $false)]
-        [string] $Name
-        , [Parameter(Mandatory = $false)]
-        [string] $Email
-        , [Parameter(Mandatory = $false)]
-        [string] $Blog
-        , [Parameter(Mandatory = $false)]
-        [string] $Company
-        , [Parameter(Mandatory = $false)]
-        [string] $Location
-        , [Parameter(Mandatory = $false)]
+        [string] $Name,
+        [Parameter(Mandatory = $false)]
+        [string] $Email,
+        [Parameter(Mandatory = $false)]
+        [string] $Blog,
+        [Parameter(Mandatory = $false)]
+        [string] $Company,
+        [Parameter(Mandatory = $false)]
+        [string] $Location,
+        [Parameter(Mandatory = $false)]
         [Alias('CanHire')]
-        [bool] $Hireable
-        , [Parameter(Mandatory = $false)]
+        [bool] $Hireable,
+        [Parameter(Mandatory = $false)]
         [Alias('Bio')]
-        [string] $Biography
-
+        [string] $Biography,
+        [Security.SecureString] $Token = (Get-GitHubToken)
     )
 
     $Body = @{
@@ -49,6 +49,6 @@ function Set-GitHubAuthenticatedUser {
     $Body = $Body | ConvertTo-Json;
     Write-Verbose -Message $Body;
 
-    Invoke-GitHubApi -RestMethod user -Body $Body -Method Patch;
+    Invoke-GitHubApi -Uri user -Body $Body -Method Patch -Token $Token;
 
 }

--- a/Functions/Public/Set-GitHubGist.ps1
+++ b/Functions/Public/Set-GitHubGist.ps1
@@ -14,12 +14,14 @@ function Set-GitHubGist {
     #>
     [CmdletBinding()]
     param (
+        [Security.SecureString] $Token = (Get-GitHubToken)
     )
 
     $ApiCall = @{
-        Body       = '';
-        RestMethod = '';
-        Method     = '';
+        Body   = '';
+        Uri    = '';
+        Method = '';
+        Token  = $Token
     }
 
     Invoke-GitHubApi @ApiCall;

--- a/Functions/Public/Set-GitHubIssue.ps1
+++ b/Functions/Public/Set-GitHubIssue.ps1
@@ -39,24 +39,25 @@ function Set-GitHubIssue {
     param (
         [Parameter(Mandatory = $true)]
         [Alias('User')]
-        [string] $Owner
-        , [Parameter(Mandatory = $true)]
-        [string] $Repository
-        , [Parameter(Mandatory = $true)]
-        [string] $Title
-        , [Parameter(Mandatory = $true)]
-        [string] $Number
-        , [Parameter(Mandatory = $false)]
-        [string] $Body
-        , [Parameter(Mandatory = $false)]
-        [string] $Assignee
-        , [Parameter(Mandatory = $false)]
-        [string[]] $Labels
-        , [Parameter(Mandatory = $false)]
-        [string] $Milestone
-        , [Parameter(Mandatory = $false)]
+        [string] $Owner,
+        [Parameter(Mandatory = $true)]
+        [string] $Repository,
+        [Parameter(Mandatory = $true)]
+        [string] $Title,
+        [Parameter(Mandatory = $true)]
+        [string] $Number,
+        [Parameter(Mandatory = $false)]
+        [string] $Body,
+        [Parameter(Mandatory = $false)]
+        [string] $Assignee,
+        [Parameter(Mandatory = $false)]
+        [string[]] $Labels,
+        [Parameter(Mandatory = $false)]
+        [string] $Milestone,
+        [Parameter(Mandatory = $false)]
         [ValidateSet('open', 'closed')]
-        [string] $State
+        [string] $State,
+        [Security.SecureString] $Token = (Get-GitHubToken)
     )
 
     ### Build the core message body -- we'll add more properties soon
@@ -84,9 +85,10 @@ function Set-GitHubIssue {
 
     ### Set up the API call
     $ApiCall = @{
-        Body       = $ApiBody | ConvertTo-Json
-        RestMethod = 'repos/{0}/{1}/issues/{2}' -f $Owner, $Repository, $Number;
-        Method     = 'Patch';
+        Body   = $ApiBody | ConvertTo-Json
+        Uri    = 'repos/{0}/{1}/issues/{2}' -f $Owner, $Repository, $Number;
+        Method = 'Patch';
+        Token  = $Token
     }
 
     ### Invoke the GitHub REST method

--- a/Functions/Public/Set-GitHubLabel.ps1
+++ b/Functions/Public/Set-GitHubLabel.ps1
@@ -55,19 +55,20 @@ function Set-GitHubLabel {
     param (
         [Parameter(Mandatory = $true, ParameterSetName = 'Repository')]
         [Alias('User')]
-        [string] $Owner
-        , [Parameter(Mandatory = $true, ParameterSetName = 'Repository')]
-        [string] $Repository
-        , [Parameter(Mandatory = $true, ParameterSetName = 'Repository')]
-        [string] $Name
-        , [Parameter(Mandatory = $false, ParameterSetName = 'Repository')]
-        [string] $NewName
-        , [Parameter(Mandatory = $false, ParameterSetName = 'Repository')]
-        [string] $Color
-        , [Parameter(Mandatory = $false, ParameterSetName = 'Repository')]
-        [string] $Description
-        , [Parameter()]
-        [switch] $Force
+        [string] $Owner,
+        [Parameter(Mandatory = $true, ParameterSetName = 'Repository')]
+        [string] $Repository,
+        [Parameter(Mandatory = $true, ParameterSetName = 'Repository')]
+        [string] $Name,
+        [Parameter(Mandatory = $false, ParameterSetName = 'Repository')]
+        [string] $NewName,
+        [Parameter(Mandatory = $false, ParameterSetName = 'Repository')]
+        [string] $Color,
+        [Parameter(Mandatory = $false, ParameterSetName = 'Repository')]
+        [string] $Description,
+        [Parameter()]
+        [switch] $Force,
+        [Security.SecureString] $Token = (Get-GitHubToken)
     )
 
     $shouldProcessCaption = 'Updating an existing GitHub label'
@@ -75,7 +76,7 @@ function Set-GitHubLabel {
     $shouldProcessWarning = 'Do you want to update the GitHub label ''{0}'' in the repository ''{1}/{2}''?' -f $Name, $Owner, $Repository
 
     if ($Force -or $PSCmdlet.ShouldProcess($shouldProcessDescription, $shouldProcessWarning, $shouldProcessCaption)) {
-        $restMethod = 'repos/{0}/{1}/labels/{2}' -f $Owner, $Repository, $Name
+        $uri = 'repos/{0}/{1}/labels/{2}' -f $Owner, $Repository, $Name
 
         $bodyProperties = @{}
 
@@ -92,12 +93,13 @@ function Set-GitHubLabel {
         }
 
         $apiCall = @{
-            Headers    = @{
+            Headers = @{
                 Accept = 'application/vnd.github.symmetra-preview+json'
             }
-            Method     = 'Patch'
-            RestMethod = $restMethod
-            Body       = $bodyProperties | ConvertTo-Json
+            Method  = 'Patch'
+            Uri     = $uri
+            Body    = $bodyProperties | ConvertTo-Json
+            Token   = $Token
         }
 
         # Variable scope ensures that parent session remains unchanged

--- a/Functions/Public/Set-GitHubRepository.ps1
+++ b/Functions/Public/Set-GitHubRepository.ps1
@@ -41,19 +41,20 @@ function Set-GitHubRepository {
     #>
     param (
         [Parameter(Mandatory = $true)]
-        [string] $Owner
-        , [Parameter(Mandatory = $true)]
-        [string] $Name
-        , [Parameter(Mandatory = $false)]
-        [string] $NewName
-        , [Parameter(Mandatory = $false)]
-        [string] $Description
-        , [Parameter(Mandatory = $false)]
-        [string] $Homepage
-        , [Parameter(Mandatory = $false)]
-        [Boolean] $DisableIssues
-        , [Parameter(Mandatory = $false)]
-        [Boolean] $Private
+        [string] $Owner,
+        [Parameter(Mandatory = $true)]
+        [string] $Name,
+        [Parameter(Mandatory = $false)]
+        [string] $NewName,
+        [Parameter(Mandatory = $false)]
+        [string] $Description,
+        [Parameter(Mandatory = $false)]
+        [string] $Homepage,
+        [Parameter(Mandatory = $false)]
+        [Boolean] $DisableIssues,
+        [Parameter(Mandatory = $false)]
+        [Boolean] $Private,
+        [Security.SecureString] $Token = (Get-GitHubToken)
     )
 
     $Body = @{
@@ -67,9 +68,10 @@ function Set-GitHubRepository {
     Write-Verbose -Message $Body;
 
     $ApiCall = @{
-        RestMethod = 'repos/{0}/{1}' -f $Owner, $Name;
-        Body       = $Body;
-        Method     = 'Patch';
+        Uri    = 'repos/{0}/{1}' -f $Owner, $Name;
+        Body   = $Body;
+        Method = 'Patch';
+        Token  = $Token
     }
     Invoke-GitHubApi @ApiCall;
 }

--- a/Functions/Public/Set-GitHubToken.ps1
+++ b/Functions/Public/Set-GitHubToken.ps1
@@ -7,8 +7,11 @@ function Set-GitHubToken {
     Created by Trevor Sullivan <trevor@trevorsullivan.net>
     #>
     [CmdletBinding()]
+    [Obsolete('Use $PSDefaultParameterValues to set the -Token parameter for all PSGitHub functions')]
     param (
     )
+
+    Write-Warning 'Set-GitHubToken is deprecated. Use $PSDefaultParameterValues to set the -Token parameter for all PSGitHub functions'
 
     ### Invoke the GitHub Personal Access Token screen
     Invoke-Expression -Command 'explorer https://github.com/settings/tokens';

--- a/Functions/Public/Test-GitHubAssignee.ps1
+++ b/Functions/Public/Test-GitHubAssignee.ps1
@@ -8,12 +8,15 @@ function Test-GitHubAssignee {
     https://developer.github.com/v3/issues/assignees/#check-assignee
     #>
     [CmdletBinding()]
-    param ()
+    param (
+        [Security.SecureString] $Token = (Get-GitHubToken)
+    )
 
     $ApiCall = @{
-        Body       = '';
-        RestMethod = '';
-        Method     = '';
+        Body   = '';
+        Uri    = '';
+        Method = '';
+        Token  = $Token
     }
 
     Invoke-GitHubApi @ApiCall;

--- a/README.md
+++ b/README.md
@@ -11,17 +11,37 @@ The PSGitHub PowerShell module contains commands to manage GitHub through its RE
 You can install the PSGitHub PowerShell module using one of the following methods.
 
 1. Install from the PowerShell Gallery (requires PowerShell 5.0+)
+   ```powershell
+   Install-Module PSGitHub
+   ```
 2. Copy-install the module to your `$env:PSModulePath`
 3. Extract the module anywhere on the filesystem, and import it explicitly, using `Import-Module`
 
-# Getting Started
+# Setup
 
-If this is your first time using the PSGitHub PowerShell module, follow these steps to get started.
+To access private repositories, make changes and have a higher rate limit, [create a GitHub token](https://github.com/settings/tokens/new).
+This token can be provided to all PSGitHub functions as a `SecureString` through the `-Token` parameter.
+You can set a default token to be used by changing `$PSDefaultParameterValues` in your `profile.ps1`:
 
-1. Import the module, if you disabled module auto-loading (*optional*)
-2. Run the `Set-GitHubToken` command
-3. Specify your GitHub username and Personal Access Token
-4. Run GitHub management commands (eg. `New-GitHubRepository`)
+### On Windows
+```powershell
+$PSDefaultParameterValues['*GitHub*:Token'] = 'YOUR_ENCRYPTED_TOKEN' | ConvertTo-SecureString
+```
+
+To get the value for `YOUR_ENCRYPTED_TOKEN`, run `Read-Host -AsSecureString | ConvertFrom-SecureString` once and paste in your token.
+
+### On macOS/Linux
+
+macOS and Linux do not have access to the Windows Data Protection API, so they cannot use `ConvertFrom-SecureString`
+to generate an encrypted plaintext version of the token without a custom encryption key.
+
+If you are not concerned about storing the token in plain text in the `profile.ps1`, you can set it like this:
+
+```powershell
+$PSDefaultParameterValues['*GitHub*:Token'] = 'YOUR_PLAINTEXT_TOKEN' | ConvertTo-SecureString -AsPlainText -Force
+```
+
+Alternatively, you could store the token in a password manager or the Keychain, then retrieve it in your profile and set it the same way.
 
 # Issues
 

--- a/Tests/Unit/psgithub.tests.ps1
+++ b/Tests/Unit/psgithub.tests.ps1
@@ -77,7 +77,7 @@ InModuleScope PSGitHub {
             $mockRepositoryName = 'WebApps'
             $mockLabelName = 'Label1'
 
-            $mockExpectedDefaultRestMethod = 'repos/{0}/{1}/labels' -f $mockOwnerName, $mockRepositoryName
+            $mockExpectedDefaultUri = 'repos/{0}/{1}/labels' -f $mockOwnerName, $mockRepositoryName
         }
 
         Context 'When getting first page of all labels in a repository' {
@@ -86,7 +86,7 @@ InModuleScope PSGitHub {
 
                 Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 1 -ParameterFilter {
                     $Method -eq 'Get' -and
-                    $RestMethod -eq $mockExpectedDefaultRestMethod
+                    $Uri -eq $mockExpectedDefaultUri
                 }
             }
         }
@@ -97,7 +97,7 @@ InModuleScope PSGitHub {
 
                 Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 1 -ParameterFilter {
                     $Method -eq 'Get' -and
-                    $RestMethod -eq ('{0}?page=2' -f $mockExpectedDefaultRestMethod)
+                    $Uri -eq ('{0}?page=2' -f $mockExpectedDefaultUri)
                 }
             }
         }
@@ -108,7 +108,7 @@ InModuleScope PSGitHub {
 
                 Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 1 -ParameterFilter {
                     $Method -eq 'Get' -and
-                    $RestMethod -eq ('{0}/{1}' -f $mockExpectedDefaultRestMethod, $mockLabelName)
+                    $Uri -eq ('{0}/{1}' -f $mockExpectedDefaultUri, $mockLabelName)
                 }
             }
         }
@@ -131,7 +131,7 @@ InModuleScope PSGitHub {
                 Color      = $mockLabelColor
             }
 
-            $mockExpectedDefaultRestMethod = 'repos/{0}/{1}/labels' -f $mockOwnerName, $mockRepositoryName
+            $mockExpectedDefaultUri = 'repos/{0}/{1}/labels' -f $mockOwnerName, $mockRepositoryName
 
             $mockExpectedDefaultRequestBody = @{
                 name  = $mockLabelName
@@ -145,7 +145,7 @@ InModuleScope PSGitHub {
 
                 Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 1 -ParameterFilter {
                     $Method -eq 'Post' -and
-                    $RestMethod -eq $mockExpectedDefaultRestMethod -and
+                    $Uri -eq $mockExpectedDefaultUri -and
                     $Body -eq ($mockExpectedDefaultRequestBody | ConvertTo-Json)
                 }
             }
@@ -163,7 +163,7 @@ InModuleScope PSGitHub {
 
                 Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 1 -ParameterFilter {
                     $Method -eq 'Post' -and
-                    $RestMethod -eq $mockExpectedDefaultRestMethod -and
+                    $Uri -eq $mockExpectedDefaultUri -and
                     $Body -eq ($mockExpectedRequestBody | ConvertTo-Json)
                 }
             }
@@ -206,7 +206,7 @@ InModuleScope PSGitHub {
                 Name       = $mockLabelName
             }
 
-            $mockExpectedDefaultRestMethod = 'repos/{0}/{1}/labels/{2}' -f $mockOwnerName, $mockRepositoryName, $mockLabelName
+            $mockExpectedDefaultUri = 'repos/{0}/{1}/labels/{2}' -f $mockOwnerName, $mockRepositoryName, $mockLabelName
         }
 
         Context 'When updating a label with a new name' {
@@ -222,7 +222,7 @@ InModuleScope PSGitHub {
 
                 Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 1 -ParameterFilter {
                     $Method -eq 'Patch' -and
-                    $RestMethod -eq $mockExpectedDefaultRestMethod -and
+                    $Uri -eq $mockExpectedDefaultUri -and
                     $Body -eq ($mockExpectedRequestBody | ConvertTo-Json)
                 }
             }
@@ -241,7 +241,7 @@ InModuleScope PSGitHub {
 
                 Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 1 -ParameterFilter {
                     $Method -eq 'Patch' -and
-                    $RestMethod -eq $mockExpectedDefaultRestMethod -and
+                    $Uri -eq $mockExpectedDefaultUri -and
                     $Body -eq ($mockExpectedRequestBody | ConvertTo-Json)
                 }
             }
@@ -260,7 +260,7 @@ InModuleScope PSGitHub {
 
                 Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 1 -ParameterFilter {
                     $Method -eq 'Patch' -and
-                    $RestMethod -eq $mockExpectedDefaultRestMethod -and
+                    $Uri -eq $mockExpectedDefaultUri -and
                     $Body -eq ($mockExpectedRequestBody | ConvertTo-Json)
                 }
             }
@@ -283,7 +283,7 @@ InModuleScope PSGitHub {
 
                 Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 1 -ParameterFilter {
                     $Method -eq 'Patch' -and
-                    $RestMethod -eq $mockExpectedDefaultRestMethod -and
+                    $Uri -eq $mockExpectedDefaultUri -and
                     $Body -eq ($mockExpectedRequestBody | ConvertTo-Json)
                 }
             }
@@ -323,7 +323,7 @@ InModuleScope PSGitHub {
                 Name       = $mockLabelName
             }
 
-            $mockExpectedDefaultRestMethod = 'repos/{0}/{1}/labels/{2}' -f $mockOwnerName, $mockRepositoryName, $mockLabelName
+            $mockExpectedDefaultUri = 'repos/{0}/{1}/labels/{2}' -f $mockOwnerName, $mockRepositoryName, $mockLabelName
         }
 
         Context 'When removing a label' {
@@ -332,7 +332,7 @@ InModuleScope PSGitHub {
 
                 Assert-MockCalled -CommandName Invoke-GitHubApi -Exactly -Times 1 -ParameterFilter {
                     $Method -eq 'Delete' -and
-                    $RestMethod -eq $mockExpectedDefaultRestMethod -and
+                    $Uri -eq $mockExpectedDefaultUri -and
                     $null -eq $Body
                 }
             }


### PR DESCRIPTION
Note, this PR is based off #45 and should be rebased after that is merged and before this is merged. To review just look at the commit https://github.com/pcgeek86/PSGitHub/commit/4259210eea3a556257893355bd21b03d0a6db809

- Allow `-Token` parameter to pass token as `SecureString` and deprecate
`Set/Get-GitHubToken` (still kept as fallback for backwards compatibility). This makes the module functional on macOS/Linux. Update setup instructions in README.
- Use token auth scheme instead of Basic. This means the username is no
longer needed and some logic is not needed anymore (base64 encoding etc).
- Rename `RestMethod` to `Uri` - the "REST method" is the HTTP method like GET, POST etc, the URL is a resource, not a method. This confused me a lot initially.
- Remove `-Preview` flag - the used `Accept` media type was only for
licenses, every resource has their own preview media types. Moved to `Get-GitHubLicense`.
- Remove else clauses that did the same as the if clause - `Headers.Add()` and `Headers.Foo =` do the same, but the former will throw if the item already exists.
- Resolve URI as relative to https://api.github.com instead of matching
- Add `User-Agent` header
- Use enum for HTTP method

Fixes #44 
Fixes #14 too

@pcgeek86 