### PR TITLE
Fix the problem when updating a label because required property is missing

### DIFF
--- a/Functions/Public/Update-GitHubLabel.ps1
+++ b/Functions/Public/Update-GitHubLabel.ps1
@@ -84,6 +84,8 @@
 
         if ($NewName) {
             $bodyProperties['name'] = $NewName
+        } else {
+            $bodyProperties['name'] = $Name
         }
 
         if ($Color) {

--- a/Tests/Unit/psgithub.tests.ps1
+++ b/Tests/Unit/psgithub.tests.ps1
@@ -218,6 +218,7 @@ InModuleScope PSGitHub {
                 Update-GitHubLabel @mockTestParameters -Confirm:$false
 
                 $mockExpectedRequestBody = @{
+                    name = $mockLabelName
                     color = $mockLabelColor
                 }
 
@@ -237,6 +238,7 @@ InModuleScope PSGitHub {
                 Update-GitHubLabel @mockTestParameters -Confirm:$false
 
                 $mockExpectedRequestBody = @{
+                    name = $mockLabelName
                     description = $mockLabelDescription
                 }
 


### PR DESCRIPTION
# Bug Fixes
- Fix the problem when updating a label
  because required property is missing (issue #56)

- Fixes #56

@felixfbecker

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pcgeek86/psgithub/58)
<!-- Reviewable:end -->
