### PR TITLE
Switch to -Include instead of -Filter to fix PWSH issue

### DIFF
--- a/PSGitHub.psm1
+++ b/PSGitHub.psm1
@@ -1,6 +1,6 @@
 ### Created by Trevor Sullivan <trevor@trevorsullivan.net>
 
-Get-ChildItem $PSScriptRoot/Functions, $PSScriptRoot/Completers -Recurse -File -Filter *.ps1 | ForEach-Object {
+Get-ChildItem $PSScriptRoot/Functions, $PSScriptRoot/Completers -Recurse -File -Include *.ps1 | ForEach-Object {
     . $_.FullName;
 }
 


### PR DESCRIPTION
I was finding that Install-Module PSGitHub worked but that many of the functions weren't working. I tracked it down to the fact that the Get-ChildItem call here wasn't recursing into the Functions directory. I think that this may be a behavior change for the -Filter parameter in PSCore, but -Include works across both PS5 and PSCore 6 so I am proposing to change.

