### PR TITLE
Fix usage of BaseBranch parameter in Get-GitHubPullRequest

### DIFF
--- a/Functions/Public/Get-GitHubPullRequest.ps1
+++ b/Functions/Public/Get-GitHubPullRequest.ps1
@@ -96,8 +96,8 @@
         if ($Labels) {
             $queryParams.labels = $Labels
         }
-        if ($Base) {
-            $queryParams.base = $Base
+        if ($BaseBranch) {
+            $queryParams.base = $BaseBranch
         }
         if ($Since) {
             $queryParams.since = $Since.ToString('o')


### PR DESCRIPTION
# Bug Fixes

- Fixes #61 


This fixes the `-BaseBranch` parameter of `Get-GitHubPullRequest`.
